### PR TITLE
Object to do all the filtering and stuff

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,7 @@
+class Game
+  attr_reader :name, :appid
+  def initialize(hash)
+    @name = hash['name']
+    @appid = hash['appid']
+  end
+end

--- a/app/models/game_finder.rb
+++ b/app/models/game_finder.rb
@@ -1,0 +1,21 @@
+class GameFinder
+  attr_reader :collection, :players, :games
+  def initialize
+    @collection = Hash.new(0)
+    @games = {}
+    @players = 0
+  end
+
+  def add_players_games(games)
+    games.each do |game|
+      self.collection[game.name] += 1
+      self.games[game.name] ||= game
+    end
+    @players += 1
+  end
+
+  def playable_games
+    owned_by_all = collection.reject { |key, value| value != players }
+    games.slice(*owned_by_all.keys).values
+  end
+end

--- a/test/models/game_finder_test.rb
+++ b/test/models/game_finder_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class GameFinderTest < ActiveSupport::TestCase
+
+  GAMES = {
+    csgo: Game.new('name' => 'CS GO', 'appid' => 1),
+    aoe2: Game.new('name' => 'AoE 2', 'appid' => 2),
+    arma3: Game.new('name' => 'Arma3', 'appid' => 3),
+    peggle: Game.new('name' => 'Peggle', 'appid' => 4)
+  }
+
+  setup do
+    @games_a = make_list %i(csgo aoe2)
+    @games_b = make_list %i(arma3 peggle aoe2)
+    @games_c = make_list %i(aoe2 arma3 peggle)
+    @all_players = [@games_a, @games_b, @games_c]
+  end
+
+  test "it should only return the games that can be played by all players" do
+    finder = GameFinder.new
+    @all_players.each { |games| finder.add_players_games(games) }
+    assert_equal [GAMES[:aoe2]], finder.playable_games
+  end
+
+  def make_list(keys)
+    keys.map{ |k| GAMES[k] }
+  end
+end


### PR DESCRIPTION
This filters out all the games that all players don't all
own. It bases it off game title for filtering at the moment
which should be fine.

"Players" are added by adding their game collections which are
lists of Game objects. These are basically plain ruby objects but
it might be nice to use a library or something that we can use to
make interfacing with these objects easier (i.e. don't need to
implement all the fields). One alternative is override method_missing
but that might be naughty. `¯\(°_o)/¯`

please review @carsonb 
