### PR TITLE
use different session identifier and stuff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,12 +43,10 @@ gem 'steam-api'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'sqlite3'
 end
 
-group :production do
-  gem 'pg'
-end
+gem 'pg'
+
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.9)
     steam-api (1.0.1)
       faraday (= 0.9.0)
       json (>= 1.7.7)
@@ -150,7 +149,6 @@ DEPENDENCIES
   rails (= 4.0.3)
   sass-rails (~> 4.0.0)
   sdoc
-  sqlite3
   steam-api
   turbolinks
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ STEAM_API_KEY: 'your steam key here'
 SECRET_TOKEN: 'probably should do something here too'
 ```
 
+We use Postgres, to get this working on your development machine, install Postgres ([Postgres.app on a Mac](http://postgresapp.com/)) and configure the db:
+
+```
+createdb steam_sauna_dev
+createuser steamsauna
+bundle install
+rake db:migrate
+```
+
 Ackowledgements
 ---------------
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
 
   before_filter :configure_steam_api_key
 
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
   def logged_in?
     current_user.present?
   end
@@ -15,7 +19,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    @current_user ||= User.find(session[:current_user]) if session[:current_user]
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
   def user_id

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -10,7 +10,7 @@ class AuthController < ApplicationController
 
     user = User.where(uid: auth.uid.to_i).first_or_initialize
     user.update_attributes(auth.info.slice('nickname', 'image'))
-    session[:current_user] = user.id
+    log_in(user)
 
     redirect_to root_url
   end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -24,6 +24,6 @@ class WelcomeController < ApplicationController
   private
 
   def steam_service
-    @steam_service ||= SteamService.new(user_id) if user_id
+    @steam_service ||= SteamService.new(current_user.uid) if logged_in?
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,10 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# You'll require a steamsauna user
+# create role steamsauna with createdb login;
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
+  adapter: postgresql
+  database: steam_sauna_dev
+  user: steamsauna
+  host: 127.0.0.1
   pool: 5
   timeout: 5000
 
@@ -13,8 +12,10 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  adapter: postgresql
+  database: steam_sauna_test
+  user: steamsauna
+  post: 127.0.0.1
   pool: 5
   timeout: 5000
 

--- a/db/migrate/20140725225557_use_bigints_yo.rb
+++ b/db/migrate/20140725225557_use_bigints_yo.rb
@@ -1,0 +1,5 @@
+class UseBigintsYo < ActiveRecord::Migration
+  def change
+    change_column :users, :uid, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140704022655) do
+ActiveRecord::Schema.define(version: 20140725225557) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "users", force: true do |t|
-    t.integer  "uid"
+    t.integer  "uid",        limit: 8
     t.string   "nickname"
     t.string   "image"
     t.text     "friends"
@@ -22,6 +25,6 @@ ActiveRecord::Schema.define(version: 20140704022655) do
     t.datetime "updated_at"
   end
 
-  add_index "users", ["uid"], name: "index_users_on_uid", unique: true
+  add_index "users", ["uid"], name: "index_users_on_uid", unique: true, using: :btree
 
 end


### PR DESCRIPTION
Use PG in development and fixes crashes

As stated in chat, this is what the issue was. While attempting to debug it a few days ago we weren't getting any analytics into the issue whatsoever (no stack traces, etc). After a recent attempt to deploy in the staging environment, it was revealed that steam uids are bigints, so this fixes the column definitions for uids to be bigint in postgres.

This does add a development dependency in that you'll need to have postgres running, but it should reduce these kinds of DB issues, which often get missed.
