### PR TITLE
Adds steps of scraper before data is actually used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'jbuilder', '~> 1.2'
 
 gem 'rest-client'
 gem 'nokogiri'
+gem 'agent'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
+gem 'rest-client'
+gem 'nokogiri'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false
@@ -45,6 +48,11 @@ gem 'thin'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+end
+
+group :test do
+  gem 'webmock'
+  gem 'minitest'
 end
 
 gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'steam-api'
 gem 'thin'
 
 group :development do
+  gem 'pry'
+  gem 'pry-debugger'
   gem 'better_errors'
   gem 'binding_of_caller'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
+    addressable (2.3.6)
     arel (4.0.2)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
@@ -40,6 +41,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     daemons (1.1.9)
     debug_inspector (0.0.2)
     erubis (2.7.0)
@@ -64,9 +67,12 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25.1)
+    mini_portile (0.5.3)
     minitest (4.7.5)
     multi_json (1.10.1)
     multipart-post (2.0.0)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     omniauth (1.2.1)
       hashie (>= 1.2, < 3)
       rack (~> 1.0)
@@ -100,7 +106,10 @@ GEM
     rake (10.3.2)
     rdoc (4.1.1)
       json (~> 1.4)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     ruby-openid (2.5.0)
+    safe_yaml (1.0.1)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -139,6 +148,9 @@ GEM
     uglifier (2.5.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    webmock (1.17.3)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -150,12 +162,16 @@ DEPENDENCIES
   figaro
   jbuilder (~> 1.2)
   jquery-rails
+  minitest
+  nokogiri
   omniauth-steam
   pg
   rails (= 4.0.3)
+  rest-client
   sass-rails (~> 4.0.0)
   sdoc
   steam-api
   thin
   turbolinks
   uglifier (>= 1.3.0)
+  webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,17 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    columnize (0.8.9)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     daemons (1.1.9)
     debug_inspector (0.0.2)
+    debugger (1.6.6)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.2)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.5)
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (2.2.1)
@@ -67,6 +74,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.3)
     minitest (4.7.5)
@@ -85,6 +93,13 @@ GEM
       omniauth-openid
     pg (0.17.1)
     polyglot (0.3.5)
+    pry (0.10.0)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-debugger (0.2.3)
+      debugger (~> 1.3)
+      pry (>= 0.9.10, < 0.11.0)
     rack (1.5.2)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
@@ -120,6 +135,7 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
+    slop (3.5.0)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -168,6 +184,8 @@ DEPENDENCIES
   nokogiri
   omniauth-steam
   pg
+  pry
+  pry-debugger
   rails (= 4.0.3)
   rest-client
   sass-rails (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     addressable (2.3.6)
+    agent (0.9.1)
     arel (4.0.2)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
@@ -156,6 +157,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  agent
   better_errors
   binding_of_caller
   coffee-rails (~> 4.0.0)

--- a/app/models/catalog_page_details.rb
+++ b/app/models/catalog_page_details.rb
@@ -1,0 +1,60 @@
+class CatalogPageDetails
+  CATEGORY_REGEX = /category2=(\d+)/
+  GAME_ID_REGEX = /steam\/apps\/(\d+)/
+
+  UNKNOWN_GAME_ID = -1
+
+  MULTIPLAYER_CATEGORY = 1
+  SINGLEPLAYER_CATEGORY = 2
+  GAME_DETAILS = '.game_area_details_specs .name a'
+
+  attr_reader :content
+  def initialize(html)
+    @content = Nokogiri::HTML(html)
+  end
+
+  def title
+    @title ||= content.css('.apphub_AppName').text
+  end
+
+  def capsule_image
+    @capsule_image ||= strip_params(content.css('link[rel="image_src"]').first['href'])
+  end
+
+  def header_image
+    @header_image ||= strip_params(content.css('.game_header_image').first['src'])
+  end
+
+  def game_id
+    @game_id ||= if game_id = header_image.match(GAME_ID_REGEX)
+      game_id[1].to_i
+    else
+      UNKNOWN_GAME_ID
+    end
+  end
+
+  def single_player?
+    details.include? SINGLEPLAYER_CATEGORY
+  end
+
+  def multi_player?
+    details.include? MULTIPLAYER_CATEGORY
+  end
+
+  def details
+    @details ||= begin
+      details = content.css(GAME_DETAILS).map do |detail|
+        if category = detail['href'].match(CATEGORY_REGEX)
+          category[1].to_i
+        end
+      end
+      details.compact
+    end
+  end
+
+  private
+  def strip_params(url)
+    uri = URI.parse(url)
+    "#{uri.scheme}://#{uri.host}#{uri.path}"
+  end
+end

--- a/app/models/catalog_page_details.rb
+++ b/app/models/catalog_page_details.rb
@@ -54,24 +54,12 @@ class CatalogPageDetails
 
   def as_hash
     {
-      multi: multi_player?,
-      single: single_player?,
-      game_id: game_id,
+      multi_player: multi_player?,
+      app_id: game_id,
       capsule_image: capsule_image,
       header_image: header_image,
       title: title
     }
-  end
-
-  class Details
-    KEYS = [:multi, :single, :game_id, :capsule_image, :header_image, :title]
-    attr_accessor :multi, :single, :game_id, :capsule_image, :header_image, :title
-
-    def initialize(details)
-      KEYS.each do |k|
-        public_send("#{k}=".to_sym, details[k])
-      end
-    end
   end
 
   private

--- a/app/models/catalog_page_details.rb
+++ b/app/models/catalog_page_details.rb
@@ -52,6 +52,28 @@ class CatalogPageDetails
     end
   end
 
+  def as_hash
+    {
+      multi: multi_player?,
+      single: single_player?,
+      game_id: game_id,
+      capsule_image: capsule_image,
+      header_image: header_image,
+      title: title
+    }
+  end
+
+  class Details
+    KEYS = [:multi, :single, :game_id, :capsule_image, :header_image, :title]
+    attr_accessor :multi, :single, :game_id, :capsule_image, :header_image, :title
+
+    def initialize(details)
+      KEYS.each do |k|
+        public_send("#{k}=".to_sym, details[k])
+      end
+    end
+  end
+
   private
   def strip_params(url)
     uri = URI.parse(url)

--- a/app/models/concerns/asynchronous_processing.rb
+++ b/app/models/concerns/asynchronous_processing.rb
@@ -1,0 +1,43 @@
+module AsynchronousProcessing
+  extend ActiveSupport::Concern
+
+  TIMEOUT = 5.0
+
+  included do
+    attr_accessor :timeout, :logger, :error
+  end
+
+  def process(stage, channel)
+    done = channel!(Integer)
+    processing = true
+    while processing do
+      select! do |s|
+        s.case(done, :receive) { processing = false}
+        blk.yield(s, done)
+        s.case(error, :receive) { |err| error << err }
+        s.timeout(timeout) { report_timeout(stage); done << 1 }
+      end
+    end
+  end
+
+  def timeout
+    @timeout || TIMEOUT
+  end
+
+  def error
+    @error ||= channel!(StandardError)
+  end
+
+  def report_timeout(stage)
+    error_message = "[#{self.class}] Received a timeout during the processing of stage: #{stage}"
+    if logger
+      logger.warn error_message
+    else
+      raise Timeout::Error, error_message
+    end
+  end
+
+  def report_error(error)
+    raise error
+  end
+end

--- a/app/models/concerns/asynchronous_processing.rb
+++ b/app/models/concerns/asynchronous_processing.rb
@@ -4,7 +4,7 @@ module AsynchronousProcessing
   TIMEOUT = 5.0
 
   included do
-    attr_accessor :timeout, :logger, :error
+    attr_accessor :timeout, :logger
   end
 
   def process(stage, &blk)
@@ -36,6 +36,10 @@ module AsynchronousProcessing
 
   def error
     @error ||= channel!(StandardError)
+  end
+
+  def error=(channel)
+    @error = channel
   end
 
   def report_timeout(stage)

--- a/app/models/game_import_pipeline.rb
+++ b/app/models/game_import_pipeline.rb
@@ -58,13 +58,14 @@ class GameImportPipeline
   end
 
   def extract_details(page_chan, count, error)
-    details_chan = channel!(CatalogPageDetails, count)
+    details_chan = channel!(CatalogPageDetails::Details, count)
     go! do
       loop do
         select! do |s|
           s.case(page_chan, :receive) do |content|
             begin
-              details_chan << CatalogPageDetails.new(content)
+              details = CatalogPageDetails.new(content)
+              details_chan << CatalogPageDetails::Details.new(details.as_hash)
             rescue => e
               error << e
             end
@@ -73,6 +74,7 @@ class GameImportPipeline
         end
       end
     end
+    details_chan
   end
 
   def import_games(details_chan, count, error, done)

--- a/app/models/game_import_pipeline.rb
+++ b/app/models/game_import_pipeline.rb
@@ -1,0 +1,107 @@
+class GameImportPipeline
+
+  TIMEOUT = 5.0
+
+  attr_accessor :timeout
+
+  def import(app_ids=[])
+    error = channel!(StandardError)
+    done = channel!(Integer)
+
+    return [] if app_ids.blank?
+    games_to_update = retrive_missing_or_outdated_games(app_ids)
+    count = games_to_update.length
+
+    pages = fetch_pages(games_to_update, count, error)
+    details = extract_details(pages, count, error)
+
+    import_games(details, count, error, done)
+
+    success = false
+
+    select! do |s|
+      s.case(done, :receive) { success = true }
+      s.case(error, :receive) { |err| report_error(err) }
+      s.timeout(timeout) { report_timeout }
+    end
+
+    success
+  end
+
+  def retrive_missing_or_outdated_games(app_ids)
+    existing_games = SteamGame.where(app_id: app_ids).pluck(:app_id, :updated_at)
+    games_to_update = existing_games.map do |app_id, updated_at|
+      if updated_at < STALE_GAME_DATA || app_ids.include?(app_id) == false
+        app_id
+      end
+    end
+    games_to_update.compact
+  end
+
+  def fetch_pages(app_ids, count, error)
+    page_chan = channel!(String, count)
+    app_ids.each do |id|
+      go! do
+        begin
+          page = SteamCatalogPage.new(app_id)
+          page_chan << page.body
+        rescue => e
+          error << e
+        end
+      end
+    end
+    page_chan
+  end
+
+  def extract_details(page_chan, count, error)
+    details_chan = channel!(CatalogPageDetails, count)
+    go! do
+      loop do
+        select! do |s|
+          s.case(page_chan, :receive) do |content|
+            begin
+              details_chan << CatalogPageDetails.new(content)
+            rescue => e
+              error << e
+            end
+          end
+          s.timeout(timeout) {}
+        end
+      end
+    end
+  end
+
+  def import_games(details_chan, count, error, done)
+    go! do
+      counter = 0
+      select! do |s|
+        s.case(details_chan, :receive) do |details|
+          build_game(details)
+          counter += 1
+          if counter == count
+            done << 1
+          end
+        end
+        s.timeout(timeout) do
+          report_timeout
+          done << 1
+        end
+      end
+    end
+  rescue => e
+    error << e
+  end
+
+  def build_game(details)
+  end
+
+  def report_error(error)
+  end
+
+  def report_timeout
+  end
+
+  def timeout
+    @timeout || TIMEOUT
+  end
+end

--- a/app/models/game_import_pipeline.rb
+++ b/app/models/game_import_pipeline.rb
@@ -15,6 +15,10 @@ class GameImportPipeline
     pages = fetch_pages(games_to_update, count, error)
     details = extract_details(pages, count, error)
 
+    complete_processing(details, count, error)
+  end
+
+  def complete_processing(details, count, error)
     processing = true
     imported_games = 0
     while processing do
@@ -91,7 +95,12 @@ class GameImportPipeline
   end
 
   def report_error(error)
-    raise error
+    if logger
+      logger.error error.message
+      logger.error error.backtrace if error.backtrace
+    else
+      raise error
+    end
   end
 
   def report_timeout(stage)

--- a/app/models/steam_catalog_page.rb
+++ b/app/models/steam_catalog_page.rb
@@ -1,0 +1,21 @@
+class SteamCatalogPage
+  def initialize(app_id, endpoint: 'http://store.steampowered.com/app')
+    @endpoint = endpoint
+    @app_id = app_id
+  end
+
+  def body
+    fetch_data
+    response.body
+  end
+
+  def url
+    "#{@endpoint}/#{@app_id}"
+  end
+
+  private
+  attr_reader :response
+  def fetch_data
+    @response ||= RestClient.get(url)
+  end
+end

--- a/app/models/steam_catalog_page.rb
+++ b/app/models/steam_catalog_page.rb
@@ -1,4 +1,5 @@
 class SteamCatalogPage
+  USER_AGENT = "SteamSauna - Making the API you didn't"
   def initialize(app_id, endpoint: 'http://store.steampowered.com/app')
     @endpoint = endpoint
     @app_id = app_id
@@ -16,6 +17,6 @@ class SteamCatalogPage
   private
   attr_reader :response
   def fetch_data
-    @response ||= RestClient.get(url)
+    @response ||= RestClient.get(url, user_agent: USER_AGENT)
   end
 end

--- a/app/models/steam_game.rb
+++ b/app/models/steam_game.rb
@@ -1,0 +1,3 @@
+class SteamGame < ActiveRecord::Base
+  serialize :categories, Array
+end

--- a/db/migrate/20140731000024_create_steam_games.rb
+++ b/db/migrate/20140731000024_create_steam_games.rb
@@ -1,0 +1,15 @@
+class CreateSteamGames < ActiveRecord::Migration
+  def change
+    create_table :steam_games do |t|
+      t.integer :app_id, :bigint, null: false
+      t.string :title, null: false
+      t.text :header_image
+      t.text :capsule_image
+      t.text :categories
+      t.boolean :multi_player
+
+      t.timestamps
+      t.index :app_id, unique: true
+    end
+  end
+end

--- a/db/migrate/20140731000024_create_steam_games.rb
+++ b/db/migrate/20140731000024_create_steam_games.rb
@@ -1,7 +1,7 @@
 class CreateSteamGames < ActiveRecord::Migration
   def change
     create_table :steam_games do |t|
-      t.integer :app_id, :bigint, null: false
+      t.integer :app_id, null: false, limit: 8
       t.string :title, null: false
       t.text :header_image
       t.text :capsule_image

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140725225557) do
+ActiveRecord::Schema.define(version: 20140731000024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "steam_games", force: true do |t|
+    t.integer  "app_id",        limit: 8, null: false
+    t.string   "title",                   null: false
+    t.text     "header_image"
+    t.text     "capsule_image"
+    t.text     "categories"
+    t.boolean  "multi_player"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "steam_games", ["app_id"], name: "index_steam_games_on_app_id", unique: true, using: :btree
 
   create_table "users", force: true do |t|
     t.integer  "uid",        limit: 8

--- a/lib/tasks/remote_tests.rake
+++ b/lib/tasks/remote_tests.rake
@@ -1,0 +1,8 @@
+namespace :test do
+  Rake::TestTask.new(:remote => 'test:prepare') do |t|
+    t.libs << 'test'
+    t.pattern = 'test/remote/**/*_test.rb'
+    t.verbose = false
+  end
+  Rake::Task['test:remote'].comment = "Run tests that make calls to external services"
+end

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 class WelcomeControllerTest < ActionController::TestCase
-  test "should get index" do
+  test "should be redirected to login page" do
     get :index
-    assert_response :success
+    assert_redirected_to login_path
   end
 
 end

--- a/test/data/game_pages/counter_strike.html
+++ b/test/data/game_pages/counter_strike.html
@@ -1,0 +1,1772 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title>Counter-Strike: Global Offensive on Steam</title>
+	<link rel="canonical" href="http://store.steampowered.com/app/730/" />
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/shared_global.css?v=_GgQ7HhT-9hE" rel="stylesheet" type="text/css" >
+<link href="http://store.akamai.steamstatic.com/public/css/styles_storev5.css?v=Zyf6A40n61wO" rel="stylesheet" type="text/css" >
+<!--[if lte IE 6]> <link href="http://store.akamai.steamstatic.com/public/css/styles_storev5_ie6.css?v=sEaT8nRDvs3H" rel="stylesheet" type="text/css" >
+ <![endif]-->
+<!--[if lte IE 7]> <style type="text/css"> .iepopupfix{ display: block; } </style> <![endif]-->
+	<link href="http://store.akamai.steamstatic.com/public/css/styles_gamev5.css?v=ZkDClsceMwrv" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/css/styles_recommended.css?v=HKpY6H76m6_m" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/user_reviews.css?v=FPoPO5VuDAmo" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/motiva_sans.css?v=ful_LJT3NQYl" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/buttons.css?v=wFCymvVRrfAO" rel="stylesheet" type="text/css" >
+			<link href="http://store.akamai.steamstatic.com/public/shared/css/apphub.css?v=TsZQrYn5T8jk" rel="stylesheet" type="text/css" >
+		<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/swfobject.js?v=.IJPsm1EB98JP"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/prototype-1.7.js?v=.a38iP7Khdmyy"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/scriptaculous/_combined.js?v=N9x7GFelaFEb&amp;l=english&amp;load=effects,controls,slider"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/javascript.js?v=FPAWUx8sdrv4&amp;l=english"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/main.js?v=E8ygY9CPHPkJ&amp;l=english"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/jquery-1.8.3.min.js?v=.TZ2NKhB-nliU"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/tooltip.js?v=.oSBHrEv5IeWE"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/shared_global.js?v=-YwK_FPSgb3j&amp;l=english"></script>
+
+<script type="text/javascript">
+$J = jQuery.noConflict();
+jQuery(document).ready(function($) { $J.data( document, 'x_readytime', new Date().getTime() ); 
+$J.data( document, 'x_oldref', GetNavCookie() ); 
+$('.tooltip').v_tooltip(); $('.supernav').v_tooltip({'location':'bottom', 'tooltipClass': 'supernav_content', 'offsetY':-4, 'offsetX': 1, 'horizontalSnap': 4, 'tooltipParent': '#supernav'});
+window.BindStoreTooltip = function( $Selector ) { $Selector.v_tooltip( {'tooltipClass': 'store_tooltip', 'dataName': 'storeTooltip' } ); };
+BindStoreTooltip( $('[data-store-tooltip]') ); 
+});</script><script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-33786258-1']);
+  _gaq.push(['_setSampleRate', '0.4']);
+  _gaq.push(['_setCustomVar', 1, 'Logged In', 'false', 2]);
+  _gaq.push(['_setCustomVar', 2, 'Client Type', 'External', 2]);
+  _gaq.push(['_setCustomVar', 3, 'Cntrlr', 'application', 3]);
+  _gaq.push(['_setCustomVar', 4, 'Method', "application\/app", 3]);
+  _gaq.push(['_trackPageview']);
+  _gaq.push(['_setSessionCookieTimeout', 900000]);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/modal.js?v=.Gl8zxCENQAoO"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/gamehighlightplayer.js?v=S_vlTFxQJm0B&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/user_reviews.js?v=2S47p-8dk_Fv&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/dselect.js?v=a9LC4YkgHGDn&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/user_reviews_store.js?v=8WEBOyFWkZXN&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/app_tagging.js?v=i2g4L38QNSg7&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/app_reporting.js?v=z3nZngxbn3Yk&amp;l=english"></script>
+	<link rel="image_src" href="http://cdn.akamai.steamstatic.com/steam/apps/730/capsule_231x87.jpg?t=1404760172">
+	<meta name="description" content="Counter-Strike: Global Offensive (CS: GO) will expand upon the team-based action gameplay that it pioneered when it was launched 12 years ago. CS: GO features new maps, characters, and weapons and delivers updated versions of the classic CS content (de_dust, etc.).">
+	<script language="JavaScript">
+    	<!--
+	function screenshot_popup( url, width, height )
+	{
+		var append = '?';
+		if ( url.indexOf( '?' ) >= 0 )
+			append = '&';
+		if ( screen.width >= 1280 && screen.height >= 1024 )
+			popup( url+append+'size=1024', 1044, 803, 1, 1 );
+		else
+			popup( url+append+'size=800', 820, 635, 1, 1 );
+	}
+
+	Event.observe( window, 'load', function() {
+		if ( Prototype.Browser.IE )
+		{
+			//trick IE6 into putting some things in the correct spot
+			$$('.discount_block').invoke( 'hide' );
+			$$('.discount_block').invoke( 'show' );
+		}
+
+		if( $('devnotes_expander') && $('devnotes_expander').getHeight() < parseInt( $('devnotes_expander').getStyle('max-height') ) ) {
+			$('devnotes_more').hide();
+		}
+
+				if ( typeof _gaq != "undefined" && _gaq )
+		{
+			_gaq.push( ['app._setAccount', 'UA-33786258-4' ] );
+			_gaq.push( ['app._setDomainName', 'store.steampowered.com' ] );
+			_gaq.push( ['app._setAllowLinker', true ] );
+			_gaq.push( ['_gat._anonymizeIp'] );
+			_gaq.push( ['app._trackPageview' ] );
+		}
+			} );
+
+	function ShowEmbedWidget( )
+	{
+		$J('#widget_create').show();
+		$J('#widget_finished').hide();
+
+		var $Content = $J('#EmbedModal');
+		$Content.detach();
+		$Content.show();
+
+		var deferred = new jQuery.Deferred();
+		var fnOK = function() { deferred.resolve(); };
+
+		var Modal = _BuildDialog( "Create Widget to Embed", $Content, [], fnOK, {} );
+		deferred.always( function() { Modal.Dismiss(); } );
+		Modal.Show();
+
+		// attach the deferred's events to the modal
+		deferred.promise( Modal );
+
+		Modal.always(
+			function() {
+				// save it away again for later
+				$Content.hide();
+				$J(document.body).append( $Content );
+			}
+		);
+	}
+
+	function ShowShareDialog( )
+	{
+		var $Content = $J('#ShareModal');
+		$Content.detach();
+		$Content.show();
+
+		ShowAlertDialog( "Share", $Content).always(
+			function() {
+				// save it away again for later
+				$Content.hide();
+				$J(document.body).append( $Content );
+			}
+		);
+
+	}
+
+	function CreateWidget( nAppId )
+	{
+		$J('#widget_create').hide();
+
+		var nSubId = $J('input[name=w_subid]').val();
+		if( !nSubId )
+			nSubId = $J('input:radio[name=w_rsubid]:checked').val();
+
+		var strDesc = $J('textarea[name=w_text]').val();
+
+		var strWidgetURL;
+		if( nSubId )
+			strWidgetURL = 'http://store.steampowered.com/widget/' + nAppId + '/' + nSubId + '/';
+		else
+			strWidgetURL = 'http://store.steampowered.com/widget/' + nAppId + '/';
+
+		if( strDesc )
+			strWidgetURL = strWidgetURL + '?t=' + encodeURIComponent( strDesc );
+
+		var strWidgetCode = '<iframe src="' + strWidgetURL + '" frameborder="0" width="646" height="190"></iframe>';
+
+		var $iframe = $J(strWidgetCode);
+
+		$J('#widget_container').empty();
+		$J('#widget_container').append($iframe);
+		$J('#widget_code').val( strWidgetCode );
+
+		$J('#widget_finished').show();
+	}
+
+
+	-->
+	</script>
+</head>
+
+<body>
+
+<div id="global_header">
+	<div class="content">
+	
+		<div class="logo">
+			<span id="logo_holder">
+				<a href="http://store.steampowered.com/">
+					<img src="http://store.akamai.steamstatic.com/public/images/v5/globalheader_logo.png" width="176" height="44">
+				</a>
+			</span>
+			<!--[if lt IE 7]>
+			<style type="text/css">
+			#logo_holder img { filter:progid:DXImageTransform.Microsoft.Alpha(opacity=0); }
+			#logo_holder { display: inline-block; width: 176px; height: 44px; filter:progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://store.akamai.steamstatic.com/public/images/v5/globalheader_logo.png'); }
+			</style>
+			<![endif]-->
+		</div>
+
+		<div style="position: absolute; left: 200px;" id="supernav">
+	<a class="menuitem supernav" href="http://store.steampowered.com/" data-tooltip-content="
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/&quot;>Featured</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/news/&quot;>News</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/recommended/&quot;>Recommended</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/my/wishlist/&quot;>Wishlist</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/stats/&quot;>STATS</a>
+	">
+		STORE	</a>
+
+
+	<a class="menuitem supernav" style="display: block" href="http://steamcommunity.com/" data-tooltip-content="
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/&quot;>Home</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/discussions/&quot;>DISCUSSIONS</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/workshop/&quot;>Workshop</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/greenlight/&quot;>Greenlight</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/market/&quot;>Market</a>
+													">
+
+		Community	</a>
+
+	
+
+	
+	<a class="menuitem" href="http://store.steampowered.com/about/">
+		ABOUT	</a>
+
+	<a class="menuitem" href="http://support.steampowered.com/">
+		SUPPORT	</a>
+</div>
+<script type="text/javascript">
+	jQuery(document).ready(function($) { 
+		$('.tooltip').v_tooltip();
+		$('.supernav').v_tooltip({'location':'bottom', 'tooltipClass': 'supernav_content', 'offsetY':-4, 'offsetX': 1, 'horizontalSnap': 4, 'tooltipParent': '#supernav', 'correctForScreenSize': false});
+	});
+</script>
+		<div id="global_actions">
+						<div id="global_action_menu">
+									<div class="header_installsteam_btn header_installsteam_btn_green">
+						<div class="header_installsteam_btn_leftcap"></div>
+						<div class="header_installsteam_btn_rightcap"></div>
+						<a class="header_installsteam_btn_content" href="http://store.steampowered.com/about/?snr=1_5_9__11">
+							Install Steam						</a>
+					</div>
+													<a class="global_action_link" href="http://store.steampowered.com/login/?snr=1_5_9__11">login</a>
+					&nbsp;|&nbsp; 
+					<span class="pulldown global_action_link" id="language_pulldown" onclick="ShowMenu( this, 'language_dropdown', 'right' );">language</span>
+					<div class="popup_block_new" id="language_dropdown" style="display: none;">
+						<div class="popup_body popup_menu">
+																							<a class="popup_menu_item tight" href="?l=bulgarian">Български (Bulgarian)</a>
+																							<a class="popup_menu_item tight" href="?l=czech">čeština (Czech)</a>
+																							<a class="popup_menu_item tight" href="?l=danish">Dansk (Danish)</a>
+																							<a class="popup_menu_item tight" href="?l=dutch">Nederlands (Dutch)</a>
+																															<a class="popup_menu_item tight" href="?l=finnish">Suomi (Finnish)</a>
+																							<a class="popup_menu_item tight" href="?l=french">Français (French)</a>
+																							<a class="popup_menu_item tight" href="?l=greek">Ελληνικά (Greek)</a>
+																							<a class="popup_menu_item tight" href="?l=german">Deutsch (German)</a>
+																							<a class="popup_menu_item tight" href="?l=hungarian">Magyar (Hungarian)</a>
+																							<a class="popup_menu_item tight" href="?l=italian">Italiano (Italian)</a>
+																							<a class="popup_menu_item tight" href="?l=japanese">日本語 (Japanese)</a>
+																															<a class="popup_menu_item tight" href="?l=koreana">한국어 (Korean)</a>
+																							<a class="popup_menu_item tight" href="?l=norwegian">Norsk (Norwegian)</a>
+																							<a class="popup_menu_item tight" href="?l=polish">Polski (Polish)</a>
+																							<a class="popup_menu_item tight" href="?l=portuguese">Português (Portuguese)</a>
+																							<a class="popup_menu_item tight" href="?l=brazilian">Português-Brasil (Portuguese-Brazil)</a>
+																							<a class="popup_menu_item tight" href="?l=russian">Русский (Russian)</a>
+																							<a class="popup_menu_item tight" href="?l=romanian">Română (Romanian)</a>
+																							<a class="popup_menu_item tight" href="?l=schinese">简体中文 (Simplified Chinese)</a>
+																							<a class="popup_menu_item tight" href="?l=spanish">Español (Spanish)</a>
+																							<a class="popup_menu_item tight" href="?l=swedish">Svenska (Swedish)</a>
+																							<a class="popup_menu_item tight" href="?l=tchinese">繁體中文 (Traditional Chinese)</a>
+																							<a class="popup_menu_item tight" href="?l=thai">ไทย (Thai)</a>
+																							<a class="popup_menu_item tight" href="?l=turkish">Türkçe (Turkish)</a>
+																							<a class="popup_menu_item tight" href="?l=ukrainian">Українська (Ukrainian)</a>
+														<a class="popup_menu_item tight" href="http://translation.steampowered.com" target="_blank">Help us translate Steam</a>
+						</div>
+					</div>
+							</div>
+		</div>
+			</div>
+</div><div id="game_background_holder"><div id="game_background" style="background-image: url(http://cdn.akamai.steamstatic.com/steam/apps/730/page.bg.jpg?t=1404760172);"></div></div><div id="store_header">
+	<div class="content">
+		<div id="store_controls">
+			<div id="cart_status_data">
+																<div class="store_header_btn_green store_header_btn" id="store_header_cart_btn" style="display: none;">
+					<div class="store_header_btn_caps store_header_btn_leftcap"></div>
+					<div class="store_header_btn_caps store_header_btn_rightcap"></div>
+					<a id="cart_link" class="store_header_btn_content" href="http://store.steampowered.com/cart/?snr=1_5_9__12">
+						Cart						(<span id="cart_item_count_value">0</span>)
+					</a>
+				</div>
+							</div>
+		</div>
+				<div id="store_nav_area">
+			<div class="store_nav_leftcap"></div>
+			<div class="store_nav_bg">
+				<div class="store_nav">
+					<a class="tab " href="http://store.steampowered.com/?snr=1_5_9__12">
+								<span>Featured Items					</a>
+										<div class="tab  flyout_tab" id="genre_tab" onmouseover="FlyoutMenu( 'genre_tab', 'genre_flyout', 'left', 'bottom' );" onmouseout="HideFlyoutMenu( event, 'genre_tab', 'genre_flyout' );">
+						<span class="pulldown">Games<span ></span></span>
+
+					</div>
+					<div class="popup_block_new flyout_tab_flyout" id="genre_flyout" style="display: none;" onmouseout="HideFlyoutMenu( event, 'genre_tab', 'genre_flyout' );">
+						<div class="popup_body popup_menu">
+																						<a class="popup_menu_item" href="http://store.steampowered.com/genre/Free%20to%20Play/?snr=1_5_9__12">
+									Free to Play								</a>
+																																																																																																																																																																																																																																																																																																																						<a class="popup_menu_item" href="http://store.steampowered.com/genre/Early%20Access/?snr=1_5_9__12">
+									Early Access								</a>
+																						<div class="hr"></div>
+							<div class="popup_menu_subheader">Browse by genre:</div>
+																																							<a class="popup_menu_item" href="http://store.steampowered.com/genre/Action/?snr=1_5_9__12">
+										Action									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Adventure/?snr=1_5_9__12">
+										Adventure									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Strategy/?snr=1_5_9__12">
+										Strategy									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/RPG/?snr=1_5_9__12">
+										RPG									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Indie/?snr=1_5_9__12">
+										Indie									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Massively%20Multiplayer/?snr=1_5_9__12">
+										Massively Multiplayer									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Casual/?snr=1_5_9__12">
+										Casual									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Simulation/?snr=1_5_9__12">
+										Simulation									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Racing/?snr=1_5_9__12">
+										Racing									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Sports/?snr=1_5_9__12">
+										Sports									</a>
+																																																																																																																																																																																											<div class="hr"></div>
+							<div class="popup_menu_subheader">
+								<div class="popup_menu_hint" data-store-tooltip="This list was created from the most popular tags assigned to games by the community.  Click for more details.">(<a href="http://store.steampowered.com/tag/">?</a>)</div>
+								Browse by tag:							</div>
+							<a class="popup_menu_item" href="http://store.steampowered.com/tag/browse/?snr=1_5_9__12">
+								See popular tags							</a>
+							<div class="hr"></div>
+							<div class="popup_menu_subheader">Browse by platform:</div>
+							<a class="popup_menu_item" href="http://store.steampowered.com/browse/mac/?snr=1_5_9__12">
+								Mac OS X							</a>
+							<a class="popup_menu_item" href="http://store.steampowered.com/browse/linux/?snr=1_5_9__12">
+								SteamOS + Linux							</a>
+						</div>
+					</div>
+										<a class="tab " href="http://store.steampowered.com/software/?snr=1_5_9__12">
+						<span>Software</span>
+					</a>
+					<a class="tab " href="http://store.steampowered.com/freestuff/demos/?snr=1_5_9__12">
+						<span>Demos</span>
+					</a>
+
+					<a class="tab " href="http://store.steampowered.com/news/?snr=1_5_9__12">
+						<span>News</span>
+					</a>
+
+
+											<a class="tab " href="http://store.steampowered.com/recommended/?snr=1_5_9__12">
+							<span>Recommended</span>
+						</a>
+					
+					<div id="store_search">
+						<form id="searchform" name="searchform" method="get" action="http://store.steampowered.com/search/" onsubmit="return SearchSuggestCheckTerm(this);">
+							<input type="hidden" name="snr" value="1_5_9__12" >
+							<div class="searchbox">
+								<input id="store_nav_search_term" name="term" type="text" class="default" value="search the store" size="22" autocomplete="off">
+								<a href="#" id="store_search_link" onclick="var form = $(this).up('form'); if ( form.onsubmit() ) form.submit(); return false;"><img src="http://store.akamai.steamstatic.com/public/images/blank.gif"></a>
+							</div>
+						</form>
+					</div>
+					<div id="searchterm_options" class="search_suggest popup_block_new" style="display: none;">
+						<div class="popup_body" style="border-top: none;">
+							<div id="search_suggestion_contents">
+							</div>
+						</div>
+					</div>
+					<script language="JavaScript">
+						$J( function() { EnableSearchSuggestions( $('searchform').elements['term'], '1_5_9_', 'CA', 'english', '623367' ); } );
+					</script>
+
+				</div>
+			</div>
+			<div class="store_nav_rightcap"></div>
+		</div>
+			</div>
+</div>
+<script type="text/javascript">
+	var g_AccountID = 0;
+	var g_sessionID = "MTU1NzExMzIzMw==";
+	var g_ServerTime = 1406761698;
+
+	$J( InitMiniprofileHovers );
+
+	</script>
+<!-- Main Background -->
+<div id="main">
+
+
+	<div id="main_content" itemscope itemtype="http://schema.org/Product">
+		<meta itemprop="image" content = "http://cdn.akamai.steamstatic.com/steam/apps/730/capsule_231x87.jpg?t=1404760172"/>
+		<div class="page_title_area game_title_area">
+			<div class="breadcrumbs">
+								<div class="blockbg">
+											<a href="http://store.steampowered.com/search/?term=&snr=1_5_9__205">All Games</a>
+																					&gt; <a href="http://store.steampowered.com/genre/Action/?snr=1_5_9__205">Action Games</a>
+															&gt; <a href="http://store.steampowered.com/app/730/?snr=1_5_9__205"><span itemprop="name">Counter-Strike: Global Offensive</span></a>
+
+				</div>
+				<div style="clear: left;"></div>
+							</div>
+            <div class="apphub_HomeHeaderContent">
+
+	<div class="apphub_HeaderStandardTop">
+				<div class="apphub_OtherSiteInfo">
+			<a class="btn_darkblue_white_innerfade btn_medium" href="http://steamcommunity.com/app/730" onclick="if ( typeof _gaq != 'undefined' && _gaq ) { _gaq.push(['app._link', 'http://steamcommunity.com/app/730']); return false;">
+				<span>Community Hub</span>
+			</a>
+		</div>
+		<div class="apphub_AppIcon"><img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/apps/730/69f7ebe2735c366c65c0b33dae00e12dc40edbe4.jpg"><div class="overlay"></div></div>
+		<div class="apphub_AppName">Counter-Strike: Global Offensive</div>
+		<div style="clear: both"></div>
+	</div>
+
+</div>
+
+		</div>
+
+		<div class="block">
+						<script type="text/javascript">
+				var strRequiredVersion = "9";
+				if ( typeof( g_bIsOnMac ) != 'undefined' && g_bIsOnMac )
+					strRequiredVersion = "10.1.0";
+
+				
+				var bShouldUseHTML5 = !swfobject.hasFlashPlayerVersion(strRequiredVersion) || BDoesUserPreferHTML5();
+			</script>
+			<div class="block_content" id="game_highlights">
+				<div class="leftcol">
+					<div class="highlight_ctn">
+						<div class="highlight_overflow">
+							<div id="highlight_player_area" >
+																	<div class="highlight_player_item highlight_movie" id="highlight_movie_81958" style="display: none;">
+										<script type="text/javascript">
+											if( bShouldUseHTML5 )
+											{
+												document.write('<video class="highlight_player_item highlight_movie" src="http://cdn.akamai.steamstatic.com/steam/apps/81958/movie480.webm?t=1346193215" data-hd-src="http://cdn.akamai.steamstatic.com/steam/apps/81958/movie_max.webm?t=1346193215" poster="http://cdn.akamai.steamstatic.com/steam/apps/81958/movie.293x165.jpg?t=1346193215" id="movie_81958" ><p>You will need to <a href="http://www.adobe.com/go/getflashplayer" target="_blank">Install</a> the latest Flash plugin to view this page properly.</p></video>');
+												jQuery("#movie_81958").videoControls();
+											}
+											else
+												document.write('<div id="movie_81958" class="highlight_flash_player_notice" style="display: none;"><p>You will need to <a href="http://www.adobe.com/go/getflashplayer" target="_blank">Install</a> the latest Flash plugin to view this page properly.</p></div>');
+										</script>
+									</div>
+								
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_34090867f1a02b6c17652ba9043e3f622ed985a9.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_34090867f1a02b6c17652ba9043e3f622ed985a9.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_1d30c9a215fd621e2fd74f40d93b71587bf6409c.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_1d30c9a215fd621e2fd74f40d93b71587bf6409c.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_baa02e979cd3852e3c4182afcd603ab64e3502f9.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_baa02e979cd3852e3c4182afcd603ab64e3502f9.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_ffe584c163a2b16e9c1b733b1c8e2ba669fb1204.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_ffe584c163a2b16e9c1b733b1c8e2ba669fb1204.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_d87c102d028d545c877363166c9d8377014f0c23.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_d87c102d028d545c877363166c9d8377014f0c23.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_9d0735a5fbe523fd39f2c69c047019843c326cea.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9d0735a5fbe523fd39f2c69c047019843c326cea.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_9d889bec419cf38910ccf72dd80f9260227408ee.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9d889bec419cf38910ccf72dd80f9260227408ee.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_ccc4ce6edd4c454b6ce7b0757e633b63aa93921d.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_ccc4ce6edd4c454b6ce7b0757e633b63aa93921d.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_9db552fd461722f1569e3292d8f2ea654c8ffdef.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9db552fd461722f1569e3292d8f2ea654c8ffdef.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_74c1a0264ceaf57e5fb51d978205045223b48a18.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_74c1a0264ceaf57e5fb51d978205045223b48a18.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_7eaa83e44f5218a7bf5f88a0c750e36052e31d7d.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_7eaa83e44f5218a7bf5f88a0c750e36052e31d7d.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_68007896ad6071b7062bac530c481e097105efc0.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_68007896ad6071b7062bac530c481e097105efc0.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_2fcee01bace72bc47a2ad0ba82620588239e93df.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_2fcee01bace72bc47a2ad0ba82620588239e93df.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_36f82c71ee2180159b060b155bf3d06dd8167327.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_36f82c71ee2180159b060b155bf3d06dd8167327.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_f5875f8de419a3d5133ae7245b8296db2c027dd8.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/730/ss_f5875f8de419a3d5133ae7245b8296db2c027dd8.1920x1080.jpg?t=1404760172"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																<script type="text/javascript">
+									var rgMovieFlashvars = {
+																					'movie_81958': {
+										        FILENAME: "http://cdn.akamai.steamstatic.com/steam/apps/81958/movieLrg.flv?t=1346193215",
+										        MOVIE_NAME: "CS%3AGO+Trailer+Long"
+										     },
+																				'' : ''
+									};
+									var rgCommonFlashVars = {
+											clientLanguage: "english",
+											capsuleSize: "huge",
+											STAGE_WIDTH: 600,
+											STAGE_HEIGHT: 338,
+									        AUTO_PLAY: "true",
+									        ALLOW_JSPAUSE: "true",
+								        	TRACK_MUTE: "true",
+								        	CHECKBOX_AUTOPLAY_SHOW: "true",
+								        	CHECKBOX_AUTOPLAY_TEXT: "Autoplay+videos"
+									};
+									var rgScreenshotURLs = {
+																					'ss_34090867f1a02b6c17652ba9043e3f622ed985a9.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_34090867f1a02b6c17652ba9043e3f622ed985a9.600x338.jpg?t=1404760172',
+																					'ss_1d30c9a215fd621e2fd74f40d93b71587bf6409c.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_1d30c9a215fd621e2fd74f40d93b71587bf6409c.600x338.jpg?t=1404760172',
+																					'ss_baa02e979cd3852e3c4182afcd603ab64e3502f9.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_baa02e979cd3852e3c4182afcd603ab64e3502f9.600x338.jpg?t=1404760172',
+																					'ss_ffe584c163a2b16e9c1b733b1c8e2ba669fb1204.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_ffe584c163a2b16e9c1b733b1c8e2ba669fb1204.600x338.jpg?t=1404760172',
+																					'ss_d87c102d028d545c877363166c9d8377014f0c23.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_d87c102d028d545c877363166c9d8377014f0c23.600x338.jpg?t=1404760172',
+																					'ss_9d0735a5fbe523fd39f2c69c047019843c326cea.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9d0735a5fbe523fd39f2c69c047019843c326cea.600x338.jpg?t=1404760172',
+																					'ss_9d889bec419cf38910ccf72dd80f9260227408ee.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9d889bec419cf38910ccf72dd80f9260227408ee.600x338.jpg?t=1404760172',
+																					'ss_ccc4ce6edd4c454b6ce7b0757e633b63aa93921d.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_ccc4ce6edd4c454b6ce7b0757e633b63aa93921d.600x338.jpg?t=1404760172',
+																					'ss_9db552fd461722f1569e3292d8f2ea654c8ffdef.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9db552fd461722f1569e3292d8f2ea654c8ffdef.600x338.jpg?t=1404760172',
+																					'ss_74c1a0264ceaf57e5fb51d978205045223b48a18.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_74c1a0264ceaf57e5fb51d978205045223b48a18.600x338.jpg?t=1404760172',
+																					'ss_7eaa83e44f5218a7bf5f88a0c750e36052e31d7d.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_7eaa83e44f5218a7bf5f88a0c750e36052e31d7d.600x338.jpg?t=1404760172',
+																					'ss_68007896ad6071b7062bac530c481e097105efc0.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_68007896ad6071b7062bac530c481e097105efc0.600x338.jpg?t=1404760172',
+																					'ss_2fcee01bace72bc47a2ad0ba82620588239e93df.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_2fcee01bace72bc47a2ad0ba82620588239e93df.600x338.jpg?t=1404760172',
+																					'ss_36f82c71ee2180159b060b155bf3d06dd8167327.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_36f82c71ee2180159b060b155bf3d06dd8167327.600x338.jpg?t=1404760172',
+																					'ss_f5875f8de419a3d5133ae7245b8296db2c027dd8.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/730/ss_f5875f8de419a3d5133ae7245b8296db2c027dd8.600x338.jpg?t=1404760172',
+																				'' : ''
+									};
+								</script>
+							</div>
+														<div id="highlight_strip">
+								<div id="highlight_strip_scroll" style="width: 1922px;">
+									<div class="highlight_selector"></div>
+
+																			<div class="highlight_strip_item highlight_strip_movie" id="thumb_movie_81958" >
+											<img class="movie_thumb" src="http://cdn.akamai.steamstatic.com/steam/apps/81958/movie.184x123.jpg?t=1346193215">
+											<div class="highlight_movie_marker"></div>
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_34090867f1a02b6c17652ba9043e3f622ed985a9.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_34090867f1a02b6c17652ba9043e3f622ed985a9.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_1d30c9a215fd621e2fd74f40d93b71587bf6409c.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_1d30c9a215fd621e2fd74f40d93b71587bf6409c.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_baa02e979cd3852e3c4182afcd603ab64e3502f9.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_baa02e979cd3852e3c4182afcd603ab64e3502f9.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_ffe584c163a2b16e9c1b733b1c8e2ba669fb1204.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_ffe584c163a2b16e9c1b733b1c8e2ba669fb1204.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_d87c102d028d545c877363166c9d8377014f0c23.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_d87c102d028d545c877363166c9d8377014f0c23.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_9d0735a5fbe523fd39f2c69c047019843c326cea.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9d0735a5fbe523fd39f2c69c047019843c326cea.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_9d889bec419cf38910ccf72dd80f9260227408ee.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9d889bec419cf38910ccf72dd80f9260227408ee.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_ccc4ce6edd4c454b6ce7b0757e633b63aa93921d.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_ccc4ce6edd4c454b6ce7b0757e633b63aa93921d.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_9db552fd461722f1569e3292d8f2ea654c8ffdef.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_9db552fd461722f1569e3292d8f2ea654c8ffdef.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_74c1a0264ceaf57e5fb51d978205045223b48a18.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_74c1a0264ceaf57e5fb51d978205045223b48a18.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_7eaa83e44f5218a7bf5f88a0c750e36052e31d7d.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_7eaa83e44f5218a7bf5f88a0c750e36052e31d7d.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_68007896ad6071b7062bac530c481e097105efc0.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_68007896ad6071b7062bac530c481e097105efc0.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_2fcee01bace72bc47a2ad0ba82620588239e93df.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_2fcee01bace72bc47a2ad0ba82620588239e93df.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_36f82c71ee2180159b060b155bf3d06dd8167327.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_36f82c71ee2180159b060b155bf3d06dd8167327.116x65.jpg?t=1404760172">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_f5875f8de419a3d5133ae7245b8296db2c027dd8.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/730/ss_f5875f8de419a3d5133ae7245b8296db2c027dd8.116x65.jpg?t=1404760172">
+										</div>
+																	</div>
+							</div>
+															<div>
+									<div class="slider" id="highlight_slider" >
+										<div class="slider_bg">
+										</div>
+										<div class="handle">
+										</div>
+									</div>
+								</div>
+								<script type="text/javascript">
+
+									Event.observe( document, 'dom:loaded', function() {
+										new HighlightPlayer( {
+											elemPlayerArea: 'highlight_player_area',
+											elemStrip: 'highlight_strip',
+											elemStripScroll: 'highlight_strip_scroll',
+											elemSlider: 'highlight_slider',
+											rgMovieFlashvars: rgMovieFlashvars,
+											rgScreenshotURLs: rgScreenshotURLs,
+											rgDefaultMovieFlashvars: rgCommonFlashVars,
+											bUseHTMLPlayer: bShouldUseHTML5
+										} );
+									} );
+
+								</script>
+													</div>
+					</div>
+				</div>
+				<div class="rightcol">
+					<div class="glance_ctn">
+						<div class="game_header_image_ctn">
+							<img class="game_header_image" src="http://cdn.akamai.steamstatic.com/steam/apps/730/header_292x136.jpg?t=1404760172">
+						</div>
+													<div class="game_description_snippet">
+								Counter-Strike: Global Offensive (CS: GO) will expand upon the team-based action gameplay that it pioneered when it was launched 12 years ago. CS: GO features new maps, characters, and weapons and delivers updated versions of the classic CS content (de_dust, etc.).							</div>
+						
+													<div class="inner_rule small_margin"></div>
+															<div>
+									Release Date: 21 Aug 2012								</div>
+																						<!-- when the javascript runs, it will set these visible or not depending on what fits in the area -->
+								<div class="glance_tags_ctn">
+									<div class="glance_tags_label">Popular user-defined tags for this product:</div>
+									<div class="glance_tags popular_tags" data-appid="730">
+																																	<a href="http://store.steampowered.com/tag/en/FPS/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													FPS												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Multiplayer/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Multiplayer												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Competitive/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Competitive												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Tactical/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Tactical												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Shooter/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Shooter												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Valve/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Valve												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Action/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Action												</a>
+																																																																																						<a href="http://store.steampowered.com/tag/en/First-Person/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													First-Person												</a>
+																																												<a href="http://store.steampowered.com/tag/en/e-sports/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													e-sports												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Steam%20Trading%20Cards/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Steam Trading Cards												</a>
+																																												<a href="http://store.steampowered.com/tag/en/PvP/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													PvP												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Hardcore/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Hardcore												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Microtransactions/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Microtransactions												</a>
+																																																																	<a href="http://store.steampowered.com/tag/en/Steam%20Workshop/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Steam Workshop												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Source%20Engine/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Source Engine												</a>
+																																																																	<a href="http://store.steampowered.com/tag/en/Kawaii/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Kawaii												</a>
+																															<div class="app_tag add_button" onclick="ShowAppTagModal( 730 )">+</div>
+									</div>
+								</div>
+																				
+						
+							<a class="linkbar" href="http://store.steampowered.com/video/730?snr=1_5_9__400">
+								<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_trailers.png"></div>
+																	Watch all 8 trailers															</a>
+
+						
+					</div>
+				</div>
+				<div style="clear: both;"></div>
+			</div>
+								</div>
+
+		
+		<div class="leftcol game_description_column">
+
+			
+						<div id="game_area_purchase">
+								
+
+								
+								
+				<!--[if lte IE 7]>
+<style type="text/css">
+.game_area_purchase_game_dropdown_right_panel .btn_addtocart { float: none; }
+</style>
+<![endif]-->
+<div class="game_area_purchase_game_wrapper">
+		<div class="game_area_purchase_game">
+		<form name="add_to_cart_16222" action="http://store.steampowered.com/cart/" method="POST">
+			<input type="hidden" name="snr" value="1_5_9__403">
+			<input type="hidden" name="action" value="add_to_cart">
+			<input type="hidden" name="sessionid" value="MTU1NzExMzIzMw==">
+			<input type="hidden" name="subid" value="16222">
+		</form>
+				<div class="game_area_purchase_platform"><span class="platform_img steamplay"></span><span class="platform_img win"></span><span class="platform_img mac"></span></div>
+		<h1>Buy Counter-Strike: Global Offensive</h1>
+						
+		
+		<div class="game_purchase_action" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+						<div class="game_purchase_action_bg">
+																			<div class="game_purchase_price price"  itemprop="price">
+							&#36;14.99 USD						</div>
+													<div class="btn_addtocart">
+					<div class="btn_addtocart_left"></div>
+					 
+						<a class="btn_addtocart_content" href="javascript:addToCart( 16222);">Add to Cart</a>
+										<div class="btn_addtocart_right"></div>
+				</div>
+							</div>
+		</div>
+	</div>
+	</div>
+	<h2 class="gradientbg">Packages that include this game</h2><div class="game_area_purchase_game_wrapper">
+		<div class="game_area_purchase_game">
+		<form name="add_to_cart_16223" action="http://store.steampowered.com/cart/" method="POST">
+			<input type="hidden" name="snr" value="1_5_9__403">
+			<input type="hidden" name="action" value="add_to_cart">
+			<input type="hidden" name="sessionid" value="MTU1NzExMzIzMw==">
+			<input type="hidden" name="subid" value="16223">
+		</form>
+				<div class="game_area_purchase_platform"><span class="platform_img steamplay"></span><span class="platform_img win"></span><span class="platform_img mac"></span></div>
+		<h1>Buy Counter-Strike Complete</h1>
+					<p class="package_contents">
+				<b>Includes 4 items:</b> 
+				Counter-Strike, Counter-Strike: Condition Zero, Counter-Strike: Source, Counter-Strike: Global Offensive			</p>
+						
+		
+		<div class="game_purchase_action">
+							<div class="game_purchase_action_bg">
+					<div class="btn_addtocart btn_packageinfo">
+						<div class="btn_addtocart_left"></div>
+						<a class="btn_addtocart_content" href="http://store.steampowered.com/sub/16223/?snr=1_5_9__403">
+							Package info						</a> 
+						<div class="btn_addtocart_right"></div>
+					</div>
+				</div>
+						<div class="game_purchase_action_bg">
+																			<div class="game_purchase_price price" >
+							&#36;29.99 USD						</div>
+													<div class="btn_addtocart">
+					<div class="btn_addtocart_left"></div>
+					 
+						<a class="btn_addtocart_content" href="javascript:addToCart( 16223);">Add to Cart</a>
+										<div class="btn_addtocart_right"></div>
+				</div>
+							</div>
+		</div>
+	</div>
+	</div>
+<div class="game_area_purchase_game_wrapper">
+		<div class="game_area_purchase_game">
+		<form name="add_to_cart_29197" action="http://store.steampowered.com/cart/" method="POST">
+			<input type="hidden" name="snr" value="1_5_9__403">
+			<input type="hidden" name="action" value="add_to_cart">
+			<input type="hidden" name="sessionid" value="MTU1NzExMzIzMw==">
+			<input type="hidden" name="subid" value="29197">
+		</form>
+				<div class="game_area_purchase_platform"><span class="platform_img steamplay"></span><span class="platform_img win"></span><span class="platform_img mac"></span></div>
+		<h1>Buy Valve Complete Pack</h1>
+					<p class="package_contents">
+				<b>Includes 24 items:</b> 
+				Counter-Strike, Team Fortress Classic, Day of Defeat, Deathmatch Classic, Half-Life: Opposing Force, Ricochet, Half-Life, Counter-Strike: Condition Zero, Half-Life: Blue Shift, Half-Life 2, Counter-Strike: Source, Half-Life: Source, Day of Defeat: Source, Half-Life 2: Deathmatch, Half-Life 2: Lost Coast, Half-Life 2: Episode One, Half-Life Deathmatch: Source, Left 4 Dead, Half-Life 2: Episode Two, Team Fortress 2, Portal, Left 4 Dead 2, Portal 2, Counter-Strike: Global Offensive			</p>
+						
+		
+		<div class="game_purchase_action">
+							<div class="game_purchase_action_bg">
+					<div class="btn_addtocart btn_packageinfo">
+						<div class="btn_addtocart_left"></div>
+						<a class="btn_addtocart_content" href="http://store.steampowered.com/sub/29197/?snr=1_5_9__403">
+							Package info						</a> 
+						<div class="btn_addtocart_right"></div>
+					</div>
+				</div>
+						<div class="game_purchase_action_bg">
+																			<div class="game_purchase_price price" >
+							&#36;99.99 USD						</div>
+													<div class="btn_addtocart">
+					<div class="btn_addtocart_left"></div>
+					 
+						<a class="btn_addtocart_content" href="javascript:addToCart( 29197);">Add to Cart</a>
+										<div class="btn_addtocart_right"></div>
+				</div>
+							</div>
+		</div>
+	</div>
+	</div>
+
+			</div>
+			<!-- game_area_purchase -->
+
+						<!-- Announcements block -->
+				<div class="early_access_announcements">
+					<h2>
+						Recent updates						<span class="note">
+							<a href="http://steamcommunity.com/gid/[g:1:3381077]/announcements/">View all <em>(24)</em></a>
+						</span>
+					</h2>
+
+											<div class="post ">
+							<div class="container">
+							<h1><a href="http://steamcommunity.com/gid/[g:1:3381077]/announcements/detail/1751086783896069815">Respecting Intellectual Property</a></h1>
+							<h2>11 June 2014</h2>
+
+								<p>Recently we received a DMCA takedown notice regarding copyright infringement with respect to the the M4A4 | Howl, and a community sticker, Howling Dawn, claiming that the artwork was not originally created by the stated contributors. This matter is extremely serious, and we have taken appropriate action to resolve it. <br><br>When we launched the <a class="bb_link" target="_blank" href="http://steamcommunity.com/workshop/browse/?appid=730&amp;section=mtxitems" >CS:GO Items Workshop</a>, our goal was to provide artists with a space to share their creative ideas. By design, the Items Workshop has very low friction for artists to submit their work – new contributions do not require Valve review or approval. To ensure that these contributions represent original content, we require that all Workshop contributors sign a <a class="bb_link" target="_blank" href="http://steamcommunity.com/workshop/workshoplegalagreement/?appid=730" >legal agreement</a> confirming that their contributions are original. We also enable the community to monitor Workshop submissions and identify copies and plagiarism via the <a class="bb_link" target="_blank" href="http://steamcommunity.com/games/SteamWorkshop/announcements/detail/1225221890776210801" >report flag</a>.<br><br>All contributors share joint responsibility for the originality of their Workshop submission, and therefore share joint liability for claims of copyright infringement. That is, if two or more artists collaborate on a submission and the submission contains intellectual property that isn’t their own, all artists involved in the submission will share in the consequences.  <br><br>For the items in question, the following steps have been taken:<br><ul class="bb_ul"><li>Both contributors have received Steam Community bans. They receive no proceeds from either item, and both items have been removed from the game. <br></li><li>For owners of the M4A4 | Howl and Howling Dawn sticker, those items have been replaced by an alternative designed by the CS:GO team. These items will never be produced again, and have been assigned the ‘Contraband’ rarity.<br></li><li>All other in-game items that involve at least one of the contributors in their revenue share have been discontinued. <br></li><li>The Huntsman Case and Community Sticker Capsule have been revised to replace the copied and discontinued items.<br></li><li>Moving forward, we will no longer work with the contributors and we will not ship any existing Workshop submission that credits their involvement.</li></ul>The cost for everyone involved in the resolution of this issue has been significant, including our players and community members. It takes considerable time and effort for the CS:GO team to resolve copyright infringement disputes, but fortunately copying is rare – the CS:GO community has submitted tens of thousands of unique entries to the Workshop, and we have shipped dozens of your designs without a problem. <br><br>To ensure that we don’t have issues in the future, we need your help. Please only contribute original work. If you see any items that appear to violate the Workshop copyright policy, please direct the copyright owner to tell us via Valve’s <a class="bb_link" target="_blank" href="https://steamcommunity.com/dmca/create/" >DMCA takedown</a> page. Together we can keep the Workshop a safe place for artists and their hard work.<br></p>
+							</div>
+							<div class="hr"></div>
+							<span class="comments">772 comments</span>
+							<span class="more"><a href="http://steamcommunity.com/gid/[g:1:3381077]/announcements/detail/1751086783896069815">Read more</a></span>
+						</div>
+
+													<div class="divider"></div>
+																	<div class="post ">
+							<div class="container">
+							<h1><a href="http://steamcommunity.com/gid/[g:1:3381077]/announcements/detail/1751086156728991654">Counter-Strike: Global Offensive Update Released</a></h1>
+							<h2>4 June 2014</h2>
+
+								<p>Release Notes for 6/4/2014<br><br>[ MATCHMAKING ]<br>- When a player has been banned for cheating (via VAC or Overwatch), all Skill Group adjustments from that player's recent wins will be reverted for their partied teammates as well as their opponents.<br><br>[ MISC ]<br>- The &quot;thirdperson&quot; and related commands are now executable by servers (for mods and plugins).<br>- Added a server convar (sv_allow_thirdperson) which allows servers to set players to third person mode.<br>- The env_fog_controller entity now has a field and input to scale the amount fog is adjusted when players zoom (with scoped weapons).<br>- Community tournament servers with built-in round backups enabled will automatically restore all player data upon reconnection and this in most cases will avoid having to load round backups.</p>
+							</div>
+							<div class="hr"></div>
+							<span class="comments">233 comments</span>
+							<span class="more"><a href="http://steamcommunity.com/gid/[g:1:3381077]/announcements/detail/1751086156728991654">Read more</a></span>
+						</div>
+
+															</div>
+			
+			
+											<div class="game_area_description">
+											<h2>Operation Breakout</h2>
+												<p><a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://www.counter-strike.net/operationbreakout"  ><img src="https://steamcdn-a.akamaihd.net/steam/apps/730/extras/store_banner.png?t=1404760172"></a><br><br><strong>Purchase an All Access Pass to get these new features:</strong><br><ul class="bb_ul"><li>Participation in Operation Missions<br></li><li>45 new weapon finishes drop as mission rewards<br></li><li>Competitive stat tracking<br></li><li>Leaderboad ranking with your friends<br></li><li>Exclusive acccess to the new Operation weapon case</li></ul></p>
+									</div>
+								<div id="game_area_description" class="game_area_description">
+				<h2>About the Game</h2>
+				Counter-Strike: Global Offensive (CS: GO) will expand upon the team-based action gameplay that it pioneered when it was launched 12 years ago.<br />
+<br />
+CS: GO features new maps, characters, and weapons and delivers updated versions of the classic CS content (de_dust, etc.). In addition, CS: GO will introduce new gameplay modes, matchmaking, leader boards, and more.<br />
+<br />
+&quot;Counter-Strike took the gaming industry by surprise when the unlikely MOD became the most played online PC action game in the world almost immediately after its release in August 1999,&quot; said Doug Lombardi at Valve. &quot;For the past 12 years, it has continued to be one of the most-played games in the world, headline competitive gaming tournaments and selling over 25 million units worldwide across the franchise. CS: GO promises to expand on CS' award-winning gameplay and deliver it to gamers on the PC as well as the next gen consoles and the Mac.&quot;			</div>
+		
+						<div id="game_area_sys_req" class="game_area_description">
+					<h2>
+						<span class="platform_img win"></span> PC System Requirements					</h2>
+
+											<div id="game_area_sys_req_full">
+							<ul>
+								<ul class="bb_ul"><li><strong>OS:</strong> Windows® 7/Vista/XP<br>	</li><li><strong>Processor:</strong> Intel® Core™ 2 Duo E6600 or AMD Phenom™ X3 8750 processor or better<br>	</li><li><strong>Memory:</strong> 1GB XP / 2GB Vista<br>	</li><li><strong>Hard Disk Space:</strong> At least 7.6GB of Space<br>	</li><li><strong>Video Card:</strong> Video card must be 256 MB or more and should be a DirectX 9-compatible with support for Pixel Shader 3.0</li></ul>							</ul>
+						</div>
+										
+					<div style="clear: both;"></div>
+				</div>
+									<div id="game_area_sys_req" class="game_area_description">
+					<h2>
+						<span class="platform_img mac"></span> Mac System Requirements					</h2>
+
+											<div id="game_area_sys_req_full">
+							<ul>
+								<ul class="bb_ul"><li><strong>OS:</strong> MacOS X 10.6.6 or higher<br>	</li><li><strong>Processor:</strong> Intel Core Duo Processor (2GHz or better)<br>	</li><li><strong>Memory:</strong> 2GB RAM<br>	</li><li><strong>Hard Disk Space:</strong> At least 7.6GB of Space<br>	</li><li><strong>Video Card:</strong> ATI Radeon HD 2400 or better / NVidia 8600M or better</li></ul>							</ul>
+						</div>
+										
+					<div style="clear: both;"></div>
+				</div>
+							
+
+		
+		
+								<div class="block">
+				<div class="block_header">
+					<div class="right">
+						<a href="http://store.steampowered.com/recommended/morelike/app/730/?snr=1_5_9__300">See all</a>
+					</div>
+					<h4>More like this</h4>
+				</div>
+				<div class="block_content nopad">
+											<a class="small_cap" href="http://store.steampowered.com/app/240/?snr=1_5_9__300" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':'240','public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+							<img class="small_cap_img" src="http://cdn.akamai.steamstatic.com/steam/apps/240/capsule_184x69.jpg?t=1360273366" border="0" width="184" height="69"/>
+							<h4>Counter-Strike: Source</h4>
+															<h5>&#36;19.99 USD</h5>
+													</a>
+											<a class="small_cap" href="http://store.steampowered.com/app/440/?snr=1_5_9__300" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':'440','public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+							<img class="small_cap_img" src="http://cdn.akamai.steamstatic.com/steam/apps/440/capsule_184x69.jpg?t=1385082418" border="0" width="184" height="69"/>
+							<h4>Team Fortress 2</h4>
+															<h5>Free to Play</h5>
+													</a>
+											<a class="small_cap" href="http://store.steampowered.com/app/570/?snr=1_5_9__300" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':570,'public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+							<img class="small_cap_img" src="http://cdn.akamai.steamstatic.com/steam/apps/570/capsule_184x69.jpg?t=1405972677" border="0" width="184" height="69"/>
+							<h4>Dota 2</h4>
+															<h5>Free To Play</h5>
+													</a>
+										<div style="clear: left;"></div>
+				</div>
+			</div>
+					
+		<script>
+	jQuery( document ).ready(function( $ ) {
+		CollapseLongReviews();
+	});
+</script>
+	<div class="user_reviews_header no_bottom_margin">
+		Helpful customer reviews				<div class="user_reviews_see_all">
+			<a href="http://store.steampowered.com/reviews/?snr=1_5_9_">About Reviews</a>
+		</div>
+			</div>
+	<div class="user_reviews_filter_bar">
+		<span class="user_reviews_filter_text">Filter:</span>
+		<div class="user_reviews_tab active" id="ReviewsTab_all">
+			<a href="javascript:void(0)" onclick="SelectReviews( 730, 'all', 9223372036854775807, 'english' );">
+				<span>Most helpful</span>
+			</a>
+		</div>
+		<div class="user_reviews_tab" id="ReviewsTab_positive">
+			<a href="javascript:void(0)" onclick="SelectReviews( 730, 'positive', 9223372036854775807, 'english' );">
+				<span>Only positive</span>
+			</a>
+		</div>
+		<div class="user_reviews_tab" id="ReviewsTab_negative">
+			<a href="javascript:void(0)" onclick="SelectReviews( 730, 'negative', 9223372036854775807, 'english' );">
+				<span>Only negative</span>
+			</a>
+		</div>
+		<div style="clear: left;"></div>
+	</div>
+
+	<div id="LoadingMoreReviewspositive" style="display: none" class="loading_more_reviews">
+		<img src="http://store.akamai.steamstatic.com/public/shared/images/throbber.gif" class="loading_more_reviews_throbber">
+		Loading reviews...	</div>
+	<div id="LoadingMoreReviewsnegative" style="display: none" class="loading_more_reviews">
+		<img src="http://store.akamai.steamstatic.com/public/shared/images/throbber.gif" class="loading_more_reviews_throbber">
+		Loading reviews...	</div>
+
+	<div id="Reviews_positive" style="display: none" class="user_reviews_container"></div>
+	<div id="Reviews_negative" style="display: none" class="user_reviews_container"></div>
+	<div id="Reviews_all" class="user_reviews_container">
+			<div id="Reviewsall0">
+			<div class="review_box">
+						<div class="header">
+				2,899 of 3,177 people (91%) found this review helpful								<div class="commentCount"><a href="http://steamcommunity.com/profiles/76561198003457024/recommended/730/">111 <img src="http://store.akamai.steamstatic.com/public/shared/images/comment_quoteicon.png" align="center"></a></div>
+							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11218251">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/profiles/76561198003457024/">
+						<div class="playerAvatar offline">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/f3/f39d5b8e676bed5c30dbf220d91e6177a809c05e.jpg" data-miniprofile="43191296">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/profiles/76561198003457024/" data-miniprofile="43191296">fokogrilo</a></div>
+								<div class="num_owned_games">104 products in account</div>
+												<div class="num_reviews">5 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/profiles/76561198003457024/recommended/730/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/profiles/76561198003457024/recommended/730/">Recommended</a></div>
+										<div class="hours">225.5 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					Kill someone with a P90 - &quot;You're a fuc**** noob!! Noob weapon!!&quot;<br>Kill someone with a P90 through a smoke - &quot;You're a fuc**** hacker!!&quot;<br>Kill someone with a AWP - &quot;You're a fuc**** noob!! Noob weapon!!&quot;<br>Kill someone with a AWP through a door - &quot;You're a fuc**** hacker!!&quot;<br>In a 1 vs 5 you die - &quot;You're a fuc**** noob!!&quot;<br>In a 1 vs 5 you win - &quot;You're a fuc**** hacker!!&quot;<br>Kill someone with a headshot - &quot;Hacker!!&quot;<br>Get headshoted by someone - &quot;Owned!!&quot; and get teabagged<br>Kill someone with a grenade - &quot;Luck!!&quot;<br>Get killed by someone with a grenade - &quot;AHAHAHAHA&quot;<br>Get teamkilled by someone - &quot;Get out of the way you fuc**** idiot!!&quot;<br>Accidentally teamkill someone - &quot;You're a fuc**** idiot!!&quot;<br>Blocked by someone - Dies<br>Accidentally blocks someone - &quot;Get out the way you fuc**** idiot!!&quot;<br>Decide to save - &quot;You're a fuc**** coward!!&quot;<br>Decide not to save - &quot;Save you fuc**** idiot!!&quot;<br>Kill someone while defending the bomb - &quot;You fuc**** camper!!&quot;<br>Kill someone while defending the hostages - &quot;You fuc**** camper!!&quot;<br>Someone dies - The deceased one starts to rage<br>Your team lose the round - Your team starts to rage<br>Your team is losing 10-2 - Someone rages quit<br>Go to the balcony in Italy - &quot;You fuc**** hacker!!&quot;<br>Worst guy receives a drop - &quot;Are you fuc**** serious!?&quot;<br>Warm up - Everybody tries to spawn kill<br>Score is 5-1 in your favor - &quot;This is a T map!&quot;<br>Score is 1-5 againts you - &quot;This is a CT map!&quot;<br>Lose the first 2 rounds - Someone asks to get kicked<br>Last round - Everybody buys Negev<br>Your team is loosinh and you are in last - Someone vote kicks you<br>Win a match - All enemy team rages<br>Lose a match - Yout team rages<br>Someone's Internet crashes - 30 minutes ban<br>Your Internet crashes - 7 days ban<br><br>10/10<br>Best rage simulator out there!					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11218251', 'all' ); return false;">Read More</a></div>
+					Posted: 13 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11218251' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11218251"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11218251' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11218251"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				8,894 of 9,898 people (90%) found this review helpful								<div class="commentCount"><a href="http://steamcommunity.com/id/kadiv/recommended/730/">121 <img src="http://store.akamai.steamstatic.com/public/shared/images/comment_quoteicon.png" align="center"></a></div>
+							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall9279237">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/kadiv/">
+						<div class="playerAvatar online">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/6e/6ef7265b875982b35e3014b938c06a64476450c8.jpg" data-miniprofile="99493655">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/kadiv/" data-miniprofile="99493655">compliKATIEd</a></div>
+								<div class="num_owned_games">85 products in account</div>
+												<div class="num_reviews">3 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/kadiv/recommended/730/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/kadiv/recommended/730/">Recommended</a></div>
+										<div class="hours">576.7 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					you either die a noob or live long enough to get called a hacker					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('9279237', 'all' ); return false;">Read More</a></div>
+					Posted: 27 February 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '9279237' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall9279237"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '9279237' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall9279237"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				3,012 of 3,361 people (90%) found this review helpful								<div class="commentCount"><a href="http://steamcommunity.com/id/TURBOSKILL/recommended/730/">69 <img src="http://store.akamai.steamstatic.com/public/shared/images/comment_quoteicon.png" align="center"></a></div>
+							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall9921920">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/TURBOSKILL/">
+						<div class="playerAvatar online">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/66/66e54aff1be3e8a8955c10554e8e7be307ad457e.jpg" data-miniprofile="41127423">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/TURBOSKILL/" data-miniprofile="41127423">TURBOSKILL</a></div>
+								<div class="num_owned_games">445 products in account</div>
+												<div class="num_reviews">2 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/TURBOSKILL/recommended/730/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/TURBOSKILL/recommended/730/">Recommended</a></div>
+										<div class="hours">894.9 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					It doesn't matter how good you are any more, you will be judged solely on the market value of your inventory.<br><br>You should have one of your several Karambit knives equipped at all times and inspect it in game whenever possible to ensure that anybody who is spectating you is aware that you are aware you're being watched and you are absolutely showing off that extremely pricey knife you own.<br><br>Your stats are irrelevant now, most people aren't even aware that the 'Tab' key actually has a function in game. It doesn't matter if you don't know what 'eco' means. Fu­ck team work. You have a 'BOOM' AWP in your inventory, as long as you have $4750 cash in game you're buying an AWP.<br><br>You will mock anyone who decided to give their Nova the 'Walnut' skin. Same goes for people who give their FAMAS the 'Doomkitty' skin. You will only equip 'StatTrak' weapons and the first thing you do when you acquire one is go on an idle server and get several hundred kills on AFK players in order to pad the stats so you don't look like a total n00b.<br><br>Whenever a new case is released you will buy as many cases and keys as it takes in order to acquire 'an Exceedingly Rare Special Item!' Disregard the fact that you will end up spending three times as much as you otherwise would've by buying this directly from the market, it's only your parents' money after all. Besides, your birthday is next month and Christmas/Easter/[insert public holiday here] is just around the corner so you won't have to wait too long before you can blow more of their money on digital goods.<br><br>You will also plaster ever single skin you own with multiple unseemly stickers with the intention of creating a unique skin for your weapon. Your 'Easy Peasy' and 'Ninjas in Pyjamas' stickers totally don't look ridiculous whatsoever. You will also name tag all of your weapons in order to add that final personal touch to the weapon you invested so much time and money in. You don't own an AK or an M4 any more, you only own weapons with names like 'xXx OG Snoop Dogg' and 'dubstep warrior'.<br><br>You now have all the knowledge required to start playing CS:GO. Go forth and procure many skins of great value.					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('9921920', 'all' ); return false;">Read More</a></div>
+					Posted: 24 April 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '9921920' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall9921920"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '9921920' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall9921920"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				1,058 of 1,209 people (88%) found this review helpful								<div class="commentCount"><a href="http://steamcommunity.com/id/teflon1/recommended/730/">37 <img src="http://store.akamai.steamstatic.com/public/shared/images/comment_quoteicon.png" align="center"></a></div>
+							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall10376788">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/teflon1/">
+						<div class="playerAvatar offline">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/1a/1a726abfcb6736e478cfdc1decbdf5860093c665.jpg" data-miniprofile="18143127">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/teflon1/" data-miniprofile="18143127">DUNCAN DONUTS</a></div>
+								<div class="num_owned_games">464 products in account</div>
+												<div class="num_reviews">5 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/teflon1/recommended/730/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/teflon1/recommended/730/">Recommended</a></div>
+										<div class="hours">19.7 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					In this game you are a Terrorist or elite Counter-Terrorist who has never fired a gun in their life before a round starts. You must help your character learn how to control their guns while killing enemies. Strangely, each character has the mysterious power to fire one or two shots without ridiculous recoil by very briefly jerking in the opposite direction they are moving in. <br><br>When your character wears a Kevlar vest, every part of your character, except the head, are made out of steel. Therefore, the only way to quickly kill people is to shoot them in the head. This can be annoying at first, but you will soon get used to shooting a small smudge of pixels on top of a character's body. <br><br>The Goddess of Guns can materialize guns in your character's hands a few seconds before a round starts. However, your character must pay for the guns, which have vastly overinflated prices. When you have the right amount of money, the Goddess will flash a menu in your character's eyes, allowing them to select the guns they want. More advanced users can make guns materialize out of thin air with their mind as long as they have the right amount of money.<br><br>Maps are often about evil terrorists trying to bomb deserted places. Vandalism is a very serious crime in the Counter-Strike series, so elite Counter-Terrorists are deployed to stop them. Unfortunately for the Terrorists, they are dumb and only packed one bomb. However, the Counter-Terrorists do not know how to pick up a dropped bomb, so the Terrorists can still pick it up after it is dropped by a fallen friend.<br><br>In some maps, the terrorists have kidnapped a janitor and low-level desk jockey in a building. The Counter-Terrorists have been deployed to save one, not both, of the hostages. In reality, this is just a thinly-veiled excuse for the CTs to murder the Terrorists while pumping rounds into the invincible hostages. One weird thing about hostage maps is that you can purchase a &quot;Hostage Rescue Kit&quot;, which somehow makes gives you the ability to put a grown man on your shoulders in a second. Perhaps it is a spell scroll that allows hostages to hover to your character's shoulders. <br><br>Overall, Counter-Strike: Global Offensive is a surprisingly solid game about people with the worst gun handling abilities ever seen on Earth. Even though your characters have the aiming abilities of someone with Parkinsons Disease, you have many tactical options that make the game very fun and dynamic. It's worth picking up.					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('10376788', 'all' ); return false;">Read More</a></div>
+					Posted: 6 June 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '10376788' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall10376788"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '10376788' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall10376788"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				4,615 of 5,442 people (85%) found this review helpful								<div class="commentCount"><a href="http://steamcommunity.com/id/Nickhotep/recommended/730/">39 <img src="http://store.akamai.steamstatic.com/public/shared/images/comment_quoteicon.png" align="center"></a></div>
+							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall9560835">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/Nickhotep/">
+						<div class="playerAvatar online">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/ab/ab9d25b1ada04b5e0f60106205304ce9be3b7818.jpg" data-miniprofile="29904706">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/Nickhotep/" data-miniprofile="29904706">Professor of Rageology at Hate U</a></div>
+								<div class="num_owned_games">269 products in account</div>
+												<div class="num_reviews">3 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/Nickhotep/recommended/730/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/Nickhotep/recommended/730/">Recommended</a></div>
+										<div class="hours">258.4 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					I shoot bullets at a person, and they die from it. <br><br>Sometimes they do not.<br><br>Sometimes they shoot me.<br><br>Very deep storytelling. <br>					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('9560835', 'all' ); return false;">Read More</a></div>
+					Posted: 19 March 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '9560835' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall9560835"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '9560835' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall9560835"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+				<div id="LoadMoreReviewsall">
+				<a href="javascript:void(0);" onclick="LoadMoreReviews( 730, 5, 9223372036854775807, 'all', 'english' );" class="btn_darkblue_white_innerfade btn_medium">
+					<span>Load More Reviews</span>
+				</a>
+			</div>
+						<div id="ViewAllReviewsall" class="view_all_reviews_btn">
+				<a href="http://steamcommunity.com/app/730/reviews/?browsefilter=toprated&snr=1_5_9_">Browse all 74,478 reviews</a>
+			</div>
+						<div id="LoadingMoreReviewsall" style="display: none" class="loading_more_reviews">
+				<img src="http://store.akamai.steamstatic.com/public/shared/images/throbber.gif" class="loading_more_reviews_throbber">
+				Loading reviews...			</div>
+		</div>
+			</div>
+		
+	</div>
+
+<!-- Right Column -->
+	<div class="rightcol">
+
+		
+		<div class="block" id="demo_block">
+		<div class="block_content block_content_inner underlined_links">
+										<div class="demo_area_button">
+																	<div class="demo_area_button">
+							<p><a href="http://store.steampowered.com/login/?redir=app%2F730">Sign in</a> to add this game to your wishlist</p>
+						</div>
+									</div>
+						<div class="demo_area_button">
+				<a class="btn_grey_black btn_medium " href="#" onclick="ShowShareDialog(); return false;"><span>Share</span></a>
+				<span style="display: inline-block; width: 5px;"></span>
+				<a class="btn_grey_black btn_medium " href="#" onclick="ShowEmbedWidget(730); return false;"><span>Embed</span></a>
+				<span style="display: inline-block; width: 5px;"></span>
+				<a id="ReportAppBtn" class="btn_grey_black btn_medium" href="javascript:void(0)" onclick="ShowReportDialog(730)"><span data-store-tooltip="Report this Product"><i class="ico16 report"></i>&nbsp;</span></a>
+			</div>
+		</div>
+	</div>
+
+
+					<div class="block communitylink">
+				<div class="block_header">
+					<h4>Community</h4>
+				</div>
+				<div class="block_content">
+					<div class="block_content_inner">
+																			<a class="linkbar" href="http://steamcommunity.com/ogg/730" target="_blank">
+								<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/v5/ico_community.gif" width="16" height="16" border="0" align="top" /></div>
+								Visit Official Game Group							</a>
+												<a class="linkbar" href="http://steamcommunity.com/actions/Search?T=ClanAccount&K=Counter-Strike%3A%20Global%20Offensive">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/v5/ico_find.png" width="16" height="16" border="0" align="top" /></div>
+							Find Community Groups						</a>
+					</div>
+
+					
+
+
+											<div class="rule"></div>
+						<div class="block_content_inner">
+							<div class="communitylink_achievementblock">
+								<div class="communitylink_achievement_inner">
+									<p>Includes 167 Steam Achievements</p>
+									<div class="communitylink_achievement_images">
+																				<div class="communitylink_achievement">
+												<img class="communitylink_achievement" title="Three the Hard Way" src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/apps/730/6ba1350f254b95e63c0ef276dcaff3937466207a.jpg">
+											</div>
+																						<div class="communitylink_achievement">
+												<img class="communitylink_achievement" title="Killanthropist" src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/apps/730/d6029b217b817879924136ec61345c9774187ffb.jpg">
+											</div>
+																						<div class="communitylink_achievement">
+												<img class="communitylink_achievement" title="Gungamer" src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/apps/730/4a64a911384776b5b22b6b625739ac80c345ad52.jpg">
+											</div>
+																																<div class="communitylink_achievement communitylink_achivement_plusmore">
+												+164											</div>
+																				<div style="clear: left;"></div>
+									</div>
+									<a class="linkbar" href="http://steamcommunity.com/stats/730/achievements">
+										<div class="rightblock">
+											<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_achievements.png">
+										</div>
+										View Achievements									</a>
+								</div>
+							</div>
+						</div>
+									</div>
+			</div>
+		
+		<div class="block game_details underlined_links">
+						<div class="block_header">
+				<h4></h4>
+			</div>
+			<div class="block_content">
+			<div class="block_content_inner" itemprop="review" itemscope itemtype="http://www.schema.org/Review">
+															<div id="game_area_metascore">
+							83							<meta itemprop="reviewRating" content = "4.15"/>
+							<meta itemprop="author" content = "Metacritic"/>
+						</div>
+											<div id="game_area_metalink"><a href="http://www.metacritic.com/game/pc/counter-strike-global-offensive" target="_blank">Read Critic Reviews</a> <img src="http://store.akamai.steamstatic.com/public/images/ico/iconExternalLink.gif" border="0" align="bottom"></div>
+															<div class="inner_rule"></div>
+				
+
+				<div class="details_block">
+				<b>Title:</b> Counter-Strike: Global Offensive<br>
+
+								<b>Genre:</b> <a href="http://store.steampowered.com/genre/Action/?snr=1_5_9__408">Action</a><br>
+				
+									<b>Developer:</b>
+																	<a href="http://store.steampowered.com/search/?developer=Valve&snr=1_5_9__408">Valve</a>
+									 	<br>
+				
+									<b>Publisher:</b>
+					<a href="http://store.steampowered.com/publisher/Valve?snr=1_5_9__408">Valve</a>					<br>
+				
+								<b>Release Date:</b> 21 Aug 2012<br>
+								<b>Languages:</b>
+
+								<table  class="game_language_options" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <th style="width: 94px;"></th>
+                        <th style="width: 62px;"><b>Interface</b></th>
+                        <th style="width: 62px;"><b>Full audio</b></th>
+                        <th style="width: 62px;"><b>Subtitles</b></th>
+                    </tr><tr><th style="width: 94px; text-align: left;">English</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/></th><th style="width: 62px;"></th></tr><tr><th style="width: 94px; text-align: left;">Czech</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr><th style="width: 94px; text-align: left;">Danish</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr><th style="width: 94px; text-align: left;">Dutch</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr><th style="width: 94px; text-align: left;">Finnish</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">French</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">German</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Hungarian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Italian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Japanese</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Korean</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Norwegian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Polish</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Portuguese</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Portuguese-Brazil</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Romanian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Russian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Simplified Chinese</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Spanish</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Swedish</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Thai</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Traditional Chinese</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Turkish</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Bulgarian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr><tr style="display: none;" class="game_language_hidden"><th style="width: 94px; text-align: left;">Ukrainian</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"></th><th style="width: 62px;"></th></tr></table><a onClick="var rows = document.getElementsByClassName('game_language_hidden'); for (var i = 0; i < rows.length; i++) { rows[i].style.display = 'table';} this.style.display = 'none';">See all 25 supported languages</a>
+								</div>
+
+
+
+				
+				<div class="details_block">
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=1"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_multiPlayer.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=1">Multi-player</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=22"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_achievements.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=22">Steam Achievements</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=15"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_stats.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=15">Stats</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=8"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_vac.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=8">Valve Anti-Cheat enabled</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=18"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_partial_controller.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=18">Partial Controller Support</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=29"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_cards.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=29">Steam Trading Cards</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=30"><img src="https://steamstore-a.akamaihd.net/public/images/ico/ico_workshop.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=30">Steam Workshop</a></div>
+						</div>
+									</div>
+
+
+
+				<div class="details_block">
+											<a class="linkbar" href="http://blog.counter-strike.net/" target="_blank">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_web.gif" width="16" height="16" border="0" align="top"  ></div>
+							Visit the website <img src="http://store.akamai.steamstatic.com/public/images/v5/ico_external_link.gif" border="0" align="bottom">
+						</a>
+					
+					
+					
+					
+					
+											<a class="linkbar" href="http://store.steampowered.com/news/?appids=730">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_history.gif" width="16" height="16" border="0" align="top" /></div>
+							View update history						</a>
+						<a class="linkbar" href="http://store.steampowered.com/news/?appids=730">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_news.gif" width="16" height="16" border="0" align="top" /></div>
+							Read related news						</a>
+									</div>
+			</div>
+			</div>
+					</div>
+
+					<div class="block">
+				<div class="block_header"><h4>Shop Merchandise Now</h4></div>
+				<div class="block_content">
+					<div class="block_content_inner">
+						<img src="http://storefront.steampowered.com/v/gfx/apps/730/extras/CSGO_ValveStore.jpg">													<a class="linkbar" target="_blank" href="http://store.valvesoftware.com/index.php?g=1">
+								<div class="rightblock">
+									<img src="http://store.akamai.steamstatic.com/public/images/ico/link_web.gif">
+								</div>
+								Shop for Counter-Strike: Global Offensive Merchandise							</a>
+											</div>
+				</div>
+			</div>
+		
+		
+		<br>
+
+
+	</div>
+	<!-- End Right Column -->
+	<div style="clear: both;"></div>
+
+			<div class="hover game_hover" id="global_hover" style="display: none; left: 0; top: 0;">
+			<div class="game_hover_box hover_box">
+				<div class="content" id="global_hover_content">
+				</div>
+			</div>
+			<div class="hover_arrow_left"></div>
+			<div class="hover_arrow_right"></div>
+		</div>
+</div>
+</div>
+
+<div id="gotSteamModal" style="display:none;">
+	<div id="top_band">
+		<div id="modal_close"><a href="javascript:hideModal('gotSteamModal')"><img src="http://store.akamai.steamstatic.com/public/images/x9x9.gif" width="9" height="9" border="0" /></a></div>
+	</div>
+	<div id="got_steam_box">
+		<h1>Got Steam?</h1>
+		<p>You need to have Steam installed to get <strong id="gotSteam_AppName"></strong></p>
+		<div id="gotsteam_buttons">
+			<a id="gotSteam_SteamURL" href="" class="btn_white leftbtn">
+				<h3>Yes, I have Steam</h3>
+				<h5>OPEN STEAM</h5>
+			</a>
+			<a href="http://store.steampowered.com/about/" class="btn_white">
+				<h3>No, I do not have Steam</h3>
+				<h5>FREE 1.5 MB DOWNLOAD</h5>
+			</a>
+			<div style="clear: left;"></div>
+		</div>
+		<div id="low_block">
+			<div id="steam_ico"><img src="http://store.akamai.steamstatic.com/public/images/steam_ico.gif" width="40" height="40" border="0" /></div>
+			Steam is the premiere desktop gaming platform. It's free to join and easy to use. <a href="http://store.steampowered.com/about/">Learn more about Steam.</a>
+		</div></div>
+</div>
+<div id="modalBG" style="display: none;"></div>
+<!-- Footer -->
+<div id="footer_spacer" class=""></div>
+<div id="footer">
+	<div class="footer_content">
+		<div class="rule"></div>
+		
+		<div id="footer_nav">
+		
+					
+							<span class="pulldown" id="footer_genre_pulldown">
+					SHOP BY GENRE				</span>
+				<div class="popup_block_new" id="footer_genre_dropdown" style="display: none;">
+					<div class="popup_body popup_menu">
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Free%20to%20Play?snr=1_44_44__20">
+								Free to Play							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Action?snr=1_44_44__20">
+								Action							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Adventure?snr=1_44_44__20">
+								Adventure							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Strategy?snr=1_44_44__20">
+								Strategy							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/RPG?snr=1_44_44__20">
+								RPG							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Indie?snr=1_44_44__20">
+								Indie							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Massively%20Multiplayer?snr=1_44_44__20">
+								Massively Multiplayer							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Casual?snr=1_44_44__20">
+								Casual							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Simulation?snr=1_44_44__20">
+								Simulation							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Racing?snr=1_44_44__20">
+								Racing							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Sports?snr=1_44_44__20">
+								Sports							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Accounting?snr=1_44_44__20">
+								Accounting							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Animation%20%26%20Modeling?snr=1_44_44__20">
+								Animation & Modeling							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Audio%20Production?snr=1_44_44__20">
+								Audio Production							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Design%20%26%20Illustration?snr=1_44_44__20">
+								Design & Illustration							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Education?snr=1_44_44__20">
+								Education							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Photo%20Editing?snr=1_44_44__20">
+								Photo Editing							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Software%20Training?snr=1_44_44__20">
+								Software Training							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Utilities?snr=1_44_44__20">
+								Utilities							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Video%20Production?snr=1_44_44__20">
+								Video Production							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Web%20Publishing?snr=1_44_44__20">
+								Web Publishing							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Early%20Access?snr=1_44_44__20">
+								Early Access							</a>
+											</div>
+				</div>
+										<span class="pulldown" id="footer_category_pulldown">
+				SHOP BY CATEGORY			</span>
+			<div class="popup_block_new" id="footer_category_dropdown" style="display: none;">
+								<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://store.steampowered.com/freestuff/demos/?snr=1_44_44__21">
+						Demos					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/freestuff/videos/?snr=1_44_44__21">
+						Videos					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/search/?category2=21&snr=1_44_44__21">
+						Downloadable Content					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/browse/publishers?snr=1_44_44__21">
+						Game Publisher Catalogs					</a>
+																<a class="popup_menu_item" href="http://store.steampowered.com/browse/ut1?snr=1_44_44__21">
+							Games Under &#36;10 USD						</a>
+											<a class="popup_menu_item" href="http://store.steampowered.com/browse/ut2?snr=1_44_44__21">
+							Games Under &#36;5 USD						</a>
+									</div>
+							</div>
+			<span class="pulldown" id="footer_steam_pulldown">
+				ABOUT STEAM			</span>
+			<div class="popup_block_new" id="footer_steam_dropdown" style="display: none;">
+								<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://store.steampowered.com/about/?snr=1_44_44__22">
+						What is Steam?					</a>
+					<!--
+					<a class="popup_menu_item" href="">
+						Download Steam now					</a>
+					-->
+					<a class="popup_menu_item" target="_blank" href="https://support.steampowered.com/kb_article.php?p_faqid=549#gifts">
+						Gifting on Steam					</a>
+					<a class="popup_menu_item" href="https://steamcommunity.com/?snr=1_44_44__22">
+						The Steam Community					</a>
+				</div>
+							</div>
+	
+			<span class="pulldown" id="footer_valve_pulldown">
+				ABOUT VALVE			</span>
+			<div class="popup_block_new" id="footer_valve_dropdown" style="display: none;">
+				<div class="popup_body popup_menu">
+					<a class="popup_menu_item" target="_blank" href="http://www.valvesoftware.com/about.html">
+						About Valve					</a>
+					<a class="popup_menu_item" target="_blank" href="http://www.valvesoftware.com/business/">
+						Business Solutions					</a>
+					<a class="popup_menu_item" target="_blank" href="http://www.steampowered.com/steamworks/">
+						Steamworks					</a>
+					<a class="popup_menu_item" target="_blank" href="http://source.valvesoftware.com/">
+						Source Engine					</a>
+					<a class="popup_menu_item" target="_blank" href="https://cafe.steampowered.com">
+						Cyber Caf&eacute;s					</a>
+					<a class="popup_menu_item" target="_blank" href="http://www.valvesoftware.com/jobs.html">
+						Jobs					</a>
+				</div>
+			</div>
+			
+			
+			<span class="pulldown" id="footer_help_pulldown">
+				HELP			</span>
+			<div class="popup_block_new" id="footer_help_dropdown" style="display: none;">
+								<div class="popup_body popup_menu">
+					<a class="popup_menu_item" target="_blank" href="http://support.steampowered.com/">
+						Support					</a>
+					<a class="popup_menu_item" target="_blank" href="http://store.steampowered.com/forums/?snr=1_44_44__23">
+						Forums					</a>
+					<a class="popup_menu_item" target="_blank" href="http://store.steampowered.com/stats/?snr=1_44_44__23">
+						Stats					</a>
+				</div>
+							</div>
+			
+			
+			<span class="pulldown" id="footer_tools_pulldown">
+				TOOLS			</span>
+			<div class="popup_block_new" id="footer_tools_dropdown" style="display: none;">
+				<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://storefront.steampowered.com/download/hldsupdatetool.exe">
+						Windows HLDS Update Tool					</a>
+					<a class="popup_menu_item" href="http://storefront.steampowered.com/download/hldsupdatetool.bin">
+						Linux HLDS Update Tool					</a>
+				</div>
+			</div>
+			
+			
+			<span class="pulldown" id="footer_feeds_pulldown">
+				NEWS FEEDS			</span>
+			<div class="popup_block_new" id="footer_feeds_dropdown" style="display: none;">
+				<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://store.steampowered.com/feeds/news.xml">
+						<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_rss2.gif" width="13" height="13" border="0" alt="" align="top">&nbsp;&nbsp;Steam News					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/feeds/newreleases.xml">
+						<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_rss2.gif" width="13" height="13" border="0" alt="" align="top">&nbsp;&nbsp;Game Releases					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/feeds/daily_deals.xml">
+						<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_rss2.gif" width="13" height="13" border="0" alt="" align="top">&nbsp;&nbsp;Daily Deals					</a>
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+			
+			<script type="text/javascript">
+				RegisterFlyout( 'footer_genre_pulldown', 'footer_genre_dropdown', null, null, true );
+				RegisterFlyout( 'footer_category_pulldown', 'footer_category_dropdown', null, null, true );
+				RegisterFlyout( 'footer_steam_pulldown', 'footer_steam_dropdown', null, null, true );
+				RegisterFlyout( 'footer_valve_pulldown', 'footer_valve_dropdown', null, null, true );
+				RegisterFlyout( 'footer_help_pulldown', 'footer_help_dropdown', null, null, true );
+				RegisterFlyout( 'footer_tools_pulldown', 'footer_tools_dropdown', null, null, true );
+				RegisterFlyout( 'footer_feeds_pulldown', 'footer_feeds_dropdown', null, null, true );
+			</script>
+		</div>
+
+		<div class="rule"></div>
+
+		<div class="btn_client_small get_game_on_steam">
+			<a target="_blank" href="http://steamcommunity.com/greenlight">Get your game on Steam</a>
+		</div>
+
+		<div>
+			<a target="_blank" href="http://www.valvesoftware.com/about.html">About Valve</a> 
+			| <a target="_blank" href="http://www.valvesoftware.com/business/">Business Solutions</a> 
+			| <a target="_blank" href="http://www.steampowered.com/steamworks/">Steamworks</a>
+			| <a target="_blank" href="http://source.valvesoftware.com/">Source Engine</a>
+			| <a target="_blank" href="https://cafe.steampowered.com">Cyber Caf&eacute;s</a> 
+			| <a target="_blank" href="http://www.valvesoftware.com/jobs.html">Jobs</a>
+		</div>
+
+
+		<div class="rule"></div>
+		<div id="footer_logo"><a target="_blank" href="http://www.valvesoftware.com"><img src="http://store.akamai.steamstatic.com/public/images/logo_valve_footer.jpg" alt="Valve Software" border="0" /></a></div>
+		<div id="footer_text">
+			<div>&copy; 2014 Valve Corporation.  All rights reserved.  All trademarks are property of their respective owners in the US and other countries.</div>
+			<div>VAT included in all prices where applicable.</div>
+			<div class="valve_links">
+			<a target="_blank" href="http://store.steampowered.com/privacy_agreement/">Privacy Policy</a>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+			<a target="_blank" href="http://www.valvesoftware.com/legal.htm">Legal</a>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+			<a target="_blank" href="http://store.steampowered.com/subscriber_agreement/">Steam Subscriber Agreement</a>
+							</div>
+		</div>
+	</div>
+</div><!-- End Footer -->
+
+<div id="EmbedModal"  style="display: none">
+	<div id="widget_create">
+		<p>You can use this widget-maker to generate a bit of HTML that can be embedded in your website to easily allow customers to purchase this game on Steam.</p>
+
+					<p class="small">There is more than one way to buy this game. Please select a specific package to create a widget for:</p>
+			<div class="w_options">
+									<div class="w_option">
+						<input type="radio" name="w_rsubid" id="wp_16222" value="16222">
+						<label for="wp_16222">Counter-Strike: Global Offensive</label>
+					</div>
+									<div class="w_option">
+						<input type="radio" name="w_rsubid" id="wp_16223" value="16223">
+						<label for="wp_16223">Counter-Strike Complete</label>
+					</div>
+									<div class="w_option">
+						<input type="radio" name="w_rsubid" id="wp_29197" value="29197">
+						<label for="wp_29197">Valve Complete Pack</label>
+					</div>
+							</div>
+				<p class="small">Enter up to 375 characters to add a description to your widget:</p>
+		<textarea name="w_text" placeholder="Counter-Strike: Global Offensive (CS: GO) will expand upon the team-based action gameplay that it pioneered when it was launched 12 years ago. CS: GO features new maps, characters, and weapons and delivers updated versions of the classic CS content (de_dust, etc.)." maxlength="375"></textarea>
+
+		<div class="buttoncontainer">
+			<a class="btn_green_white_innerfade btn_medium " href="#" onclick="CreateWidget(730); return false;"><span>Create widget</span></a>
+		</div>
+	</div>
+	<div id="widget_finished" style="display: none;">
+		<div id="widget_container"></div>
+
+		<p class="small">Copy and paste the HTML below into your website to make the above widget appear</p>
+		<textarea id="widget_code" style=""></textarea>
+	</div>
+
+</div>
+
+<div id="ShareModal" style="display: none">
+	<div class="share">Share:&nbsp; <a target="_blank" href="http://store.steampowered.com/share/facebook/app/730" title="Share on Facebook"><img src="http://store.akamai.steamstatic.com/public/images/v5/social/facebook.gif"></a>&nbsp; <a target="_blank" href="http://store.steampowered.com/share/twitter/app/730" title="Share on Twitter"><img src="http://store.akamai.steamstatic.com/public/images/v5/social/twitter.gif"></a>&nbsp; <a target="_blank" href="http://store.steampowered.com/share/reddit/app/730" title="Share on Reddit"><img src="http://store.akamai.steamstatic.com/public/images/v5/social/reddit.gif"></a></div></div>
+
+	<div id="app_tagging_modal" class="app_tag_modal nologin" style="display: none;">
+		<div class="app_tag_modal_content">
+			<div class="app_tag_modal_seperator"></div>
+			<div class="app_tag_modal_left">
+				<h2>Popular user-defined tags for this product:<span class="app_tag_modal_tooltip" data-store-tooltip="These are tags applied to the product by the most users.  You can click a tag to find other products with that tag applied.  Or, you can hit the plus symbol for any existing tags to increase that tag's popularity on this product.">(?)</span></h2>
+				<div class="app_tags popular_tags">
+				</div>
+			</div>
+			<div class="app_tag_modal_right">
+									<h2>Sign in</h2>
+					<p>Sign in to add your own tags to this product.</p>
+					<p>
+						<a class="btn_green_white_innerfade btn_medium" href="https://store.steampowered.com/login/?redir=app/730">
+							<span>Sign in</span>
+						</a>
+					</p>
+							</div>
+			<div style="clear: both;"></div>
+		</div>
+		<div class="app_tag_modal_beta_callout">
+			<img src="http://store.akamai.steamstatic.com/public/images/v6/tag_betatag.png">
+			Steam tagging is in beta.  Click <a href="http://store.steampowered.com/tag/">here</a> to learn more.		</div>
+	</div>
+		<script type="text/javascript">
+		$J( function() {
+			InitAppTagModal( 730,
+				[{"tagid":1663,"name":"FPS","count":1856,"browseable":true},{"tagid":3859,"name":"Multiplayer","count":1711,"browseable":true},{"tagid":3878,"name":"Competitive","count":1588,"browseable":true},{"tagid":1708,"name":"Tactical","count":1257,"browseable":true},{"tagid":1774,"name":"Shooter","count":1234,"browseable":true},{"tagid":4127,"name":"Valve","count":1019,"browseable":true},{"tagid":19,"name":"Action","count":1006,"browseable":true},{"tagid":1709,"name":"Team","count":891,"browseable":false},{"tagid":3989,"name":"Marketable Items","count":750,"browseable":false},{"tagid":3839,"name":"First-Person","count":746,"browseable":true},{"tagid":5055,"name":"e-sports","count":728,"browseable":true},{"tagid":6114,"name":"Steam Trading Cards","count":546,"browseable":true},{"tagid":1775,"name":"PvP","count":492,"browseable":true},{"tagid":1764,"name":"Hardcore","count":490,"browseable":true},{"tagid":3873,"name":"Microtransactions","count":461,"browseable":true},{"tagid":4333,"name":"Tense Shooter","count":319,"browseable":false},{"tagid":5249,"name":"Steam Workshop","count":290,"browseable":true},{"tagid":6053,"name":"Source Engine","count":275,"browseable":true},{"tagid":4273,"name":"Trading Cards","count":222,"browseable":false},{"tagid":6010,"name":"Kawaii","count":107,"browseable":true}],
+				[],
+				"1_5_9__410",
+				"1_5_9__411",
+				null			);
+		})
+	</script>
+
+</body>
+</html>

--- a/test/data/game_pages/necrodancer.html
+++ b/test/data/game_pages/necrodancer.html
@@ -1,0 +1,1653 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title>Crypt of the NecroDancer on Steam</title>
+	<link rel="canonical" href="http://store.steampowered.com/app/247080/" />
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/shared_global.css?v=_GgQ7HhT-9hE" rel="stylesheet" type="text/css" >
+<link href="http://store.akamai.steamstatic.com/public/css/styles_storev5.css?v=Zyf6A40n61wO" rel="stylesheet" type="text/css" >
+<!--[if lte IE 6]> <link href="http://store.akamai.steamstatic.com/public/css/styles_storev5_ie6.css?v=sEaT8nRDvs3H" rel="stylesheet" type="text/css" >
+ <![endif]-->
+<!--[if lte IE 7]> <style type="text/css"> .iepopupfix{ display: block; } </style> <![endif]-->
+	<link href="http://store.akamai.steamstatic.com/public/css/styles_gamev5.css?v=ZkDClsceMwrv" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/css/styles_recommended.css?v=HKpY6H76m6_m" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/user_reviews.css?v=FPoPO5VuDAmo" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/motiva_sans.css?v=ful_LJT3NQYl" rel="stylesheet" type="text/css" >
+	<link href="http://store.akamai.steamstatic.com/public/shared/css/buttons.css?v=wFCymvVRrfAO" rel="stylesheet" type="text/css" >
+			<link href="http://store.akamai.steamstatic.com/public/shared/css/apphub.css?v=TsZQrYn5T8jk" rel="stylesheet" type="text/css" >
+		<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/swfobject.js?v=.IJPsm1EB98JP"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/prototype-1.7.js?v=.a38iP7Khdmyy"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/scriptaculous/_combined.js?v=N9x7GFelaFEb&amp;l=english&amp;load=effects,controls,slider"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/javascript.js?v=FPAWUx8sdrv4&amp;l=english"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/main.js?v=E8ygY9CPHPkJ&amp;l=english"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/jquery-1.8.3.min.js?v=.TZ2NKhB-nliU"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/tooltip.js?v=.oSBHrEv5IeWE"></script>
+
+<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/shared_global.js?v=-YwK_FPSgb3j&amp;l=english"></script>
+
+<script type="text/javascript">
+$J = jQuery.noConflict();
+jQuery(document).ready(function($) { $J.data( document, 'x_readytime', new Date().getTime() ); 
+$J.data( document, 'x_oldref', GetNavCookie() ); 
+$('.tooltip').v_tooltip(); $('.supernav').v_tooltip({'location':'bottom', 'tooltipClass': 'supernav_content', 'offsetY':-4, 'offsetX': 1, 'horizontalSnap': 4, 'tooltipParent': '#supernav'});
+window.BindStoreTooltip = function( $Selector ) { $Selector.v_tooltip( {'tooltipClass': 'store_tooltip', 'dataName': 'storeTooltip' } ); };
+BindStoreTooltip( $('[data-store-tooltip]') ); 
+});</script><script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-33786258-1']);
+  _gaq.push(['_setSampleRate', '0.4']);
+  _gaq.push(['_setCustomVar', 1, 'Logged In', 'false', 2]);
+  _gaq.push(['_setCustomVar', 2, 'Client Type', 'External', 2]);
+  _gaq.push(['_setCustomVar', 3, 'Cntrlr', 'application', 3]);
+  _gaq.push(['_setCustomVar', 4, 'Method', "application\/app", 3]);
+  _gaq.push(['_trackPageview']);
+  _gaq.push(['_setSessionCookieTimeout', 900000]);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/modal.js?v=.Gl8zxCENQAoO"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/gamehighlightplayer.js?v=S_vlTFxQJm0B&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/shared/javascript/user_reviews.js?v=2S47p-8dk_Fv&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/dselect.js?v=a9LC4YkgHGDn&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/user_reviews_store.js?v=8WEBOyFWkZXN&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/app_tagging.js?v=i2g4L38QNSg7&amp;l=english"></script>
+	<script type="text/javascript" src="http://store.akamai.steamstatic.com/public/javascript/app_reporting.js?v=z3nZngxbn3Yk&amp;l=english"></script>
+	<link rel="image_src" href="http://cdn.akamai.steamstatic.com/steam/apps/247080/capsule_231x87.jpg?t=1406743038">
+	<meta name="description" content="Crypt of the NecroDancer is a hardcore roguelike rhythm game. Can you survive this deadly dungeon of dance? Groove to the epic Danny Baranowsky soundtrack, or select songs from your own MP3 collection!">
+	<script language="JavaScript">
+    	<!--
+	function screenshot_popup( url, width, height )
+	{
+		var append = '?';
+		if ( url.indexOf( '?' ) >= 0 )
+			append = '&';
+		if ( screen.width >= 1280 && screen.height >= 1024 )
+			popup( url+append+'size=1024', 1044, 803, 1, 1 );
+		else
+			popup( url+append+'size=800', 820, 635, 1, 1 );
+	}
+
+	Event.observe( window, 'load', function() {
+		if ( Prototype.Browser.IE )
+		{
+			//trick IE6 into putting some things in the correct spot
+			$$('.discount_block').invoke( 'hide' );
+			$$('.discount_block').invoke( 'show' );
+		}
+
+		if( $('devnotes_expander') && $('devnotes_expander').getHeight() < parseInt( $('devnotes_expander').getStyle('max-height') ) ) {
+			$('devnotes_more').hide();
+		}
+
+				if ( typeof _gaq != "undefined" && _gaq )
+		{
+			_gaq.push( ['app._setAccount', 'UA-39517709-3' ] );
+			_gaq.push( ['app._setDomainName', 'store.steampowered.com' ] );
+			_gaq.push( ['app._setAllowLinker', true ] );
+			_gaq.push( ['_gat._anonymizeIp'] );
+			_gaq.push( ['app._trackPageview' ] );
+		}
+			} );
+
+	function ShowEmbedWidget( )
+	{
+		$J('#widget_create').show();
+		$J('#widget_finished').hide();
+
+		var $Content = $J('#EmbedModal');
+		$Content.detach();
+		$Content.show();
+
+		var deferred = new jQuery.Deferred();
+		var fnOK = function() { deferred.resolve(); };
+
+		var Modal = _BuildDialog( "Create Widget to Embed", $Content, [], fnOK, {} );
+		deferred.always( function() { Modal.Dismiss(); } );
+		Modal.Show();
+
+		// attach the deferred's events to the modal
+		deferred.promise( Modal );
+
+		Modal.always(
+			function() {
+				// save it away again for later
+				$Content.hide();
+				$J(document.body).append( $Content );
+			}
+		);
+	}
+
+	function ShowShareDialog( )
+	{
+		var $Content = $J('#ShareModal');
+		$Content.detach();
+		$Content.show();
+
+		ShowAlertDialog( "Share", $Content).always(
+			function() {
+				// save it away again for later
+				$Content.hide();
+				$J(document.body).append( $Content );
+			}
+		);
+
+	}
+
+	function CreateWidget( nAppId )
+	{
+		$J('#widget_create').hide();
+
+		var nSubId = $J('input[name=w_subid]').val();
+		if( !nSubId )
+			nSubId = $J('input:radio[name=w_rsubid]:checked').val();
+
+		var strDesc = $J('textarea[name=w_text]').val();
+
+		var strWidgetURL;
+		if( nSubId )
+			strWidgetURL = 'http://store.steampowered.com/widget/' + nAppId + '/' + nSubId + '/';
+		else
+			strWidgetURL = 'http://store.steampowered.com/widget/' + nAppId + '/';
+
+		if( strDesc )
+			strWidgetURL = strWidgetURL + '?t=' + encodeURIComponent( strDesc );
+
+		var strWidgetCode = '<iframe src="' + strWidgetURL + '" frameborder="0" width="646" height="190"></iframe>';
+
+		var $iframe = $J(strWidgetCode);
+
+		$J('#widget_container').empty();
+		$J('#widget_container').append($iframe);
+		$J('#widget_code').val( strWidgetCode );
+
+		$J('#widget_finished').show();
+	}
+
+
+	-->
+	</script>
+</head>
+
+<body>
+
+<div id="global_header">
+	<div class="content">
+	
+		<div class="logo">
+			<span id="logo_holder">
+				<a href="http://store.steampowered.com/">
+					<img src="http://store.akamai.steamstatic.com/public/images/v5/globalheader_logo.png" width="176" height="44">
+				</a>
+			</span>
+			<!--[if lt IE 7]>
+			<style type="text/css">
+			#logo_holder img { filter:progid:DXImageTransform.Microsoft.Alpha(opacity=0); }
+			#logo_holder { display: inline-block; width: 176px; height: 44px; filter:progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://store.akamai.steamstatic.com/public/images/v5/globalheader_logo.png'); }
+			</style>
+			<![endif]-->
+		</div>
+
+		<div style="position: absolute; left: 200px;" id="supernav">
+	<a class="menuitem supernav" href="http://store.steampowered.com/" data-tooltip-content="
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/&quot;>Featured</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/news/&quot;>News</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/recommended/&quot;>Recommended</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/my/wishlist/&quot;>Wishlist</a>
+		<a class=&quot;submenuitem&quot; href=&quot;http://store.steampowered.com/stats/&quot;>STATS</a>
+	">
+		STORE	</a>
+
+
+	<a class="menuitem supernav" style="display: block" href="http://steamcommunity.com/" data-tooltip-content="
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/&quot;>Home</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/discussions/&quot;>DISCUSSIONS</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/workshop/&quot;>Workshop</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/greenlight/&quot;>Greenlight</a>
+					<a class=&quot;submenuitem&quot; href=&quot;http://steamcommunity.com/market/&quot;>Market</a>
+													">
+
+		Community	</a>
+
+	
+
+	
+	<a class="menuitem" href="http://store.steampowered.com/about/">
+		ABOUT	</a>
+
+	<a class="menuitem" href="http://support.steampowered.com/">
+		SUPPORT	</a>
+</div>
+<script type="text/javascript">
+	jQuery(document).ready(function($) { 
+		$('.tooltip').v_tooltip();
+		$('.supernav').v_tooltip({'location':'bottom', 'tooltipClass': 'supernav_content', 'offsetY':-4, 'offsetX': 1, 'horizontalSnap': 4, 'tooltipParent': '#supernav', 'correctForScreenSize': false});
+	});
+</script>
+		<div id="global_actions">
+						<div id="global_action_menu">
+									<div class="header_installsteam_btn header_installsteam_btn_green">
+						<div class="header_installsteam_btn_leftcap"></div>
+						<div class="header_installsteam_btn_rightcap"></div>
+						<a class="header_installsteam_btn_content" href="http://store.steampowered.com/about/?snr=1_5_9__11">
+							Install Steam						</a>
+					</div>
+													<a class="global_action_link" href="http://store.steampowered.com/login/?snr=1_5_9__11">login</a>
+					&nbsp;|&nbsp; 
+					<span class="pulldown global_action_link" id="language_pulldown" onclick="ShowMenu( this, 'language_dropdown', 'right' );">language</span>
+					<div class="popup_block_new" id="language_dropdown" style="display: none;">
+						<div class="popup_body popup_menu">
+																							<a class="popup_menu_item tight" href="?l=bulgarian">Български (Bulgarian)</a>
+																							<a class="popup_menu_item tight" href="?l=czech">čeština (Czech)</a>
+																							<a class="popup_menu_item tight" href="?l=danish">Dansk (Danish)</a>
+																							<a class="popup_menu_item tight" href="?l=dutch">Nederlands (Dutch)</a>
+																															<a class="popup_menu_item tight" href="?l=finnish">Suomi (Finnish)</a>
+																							<a class="popup_menu_item tight" href="?l=french">Français (French)</a>
+																							<a class="popup_menu_item tight" href="?l=greek">Ελληνικά (Greek)</a>
+																							<a class="popup_menu_item tight" href="?l=german">Deutsch (German)</a>
+																							<a class="popup_menu_item tight" href="?l=hungarian">Magyar (Hungarian)</a>
+																							<a class="popup_menu_item tight" href="?l=italian">Italiano (Italian)</a>
+																							<a class="popup_menu_item tight" href="?l=japanese">日本語 (Japanese)</a>
+																															<a class="popup_menu_item tight" href="?l=koreana">한국어 (Korean)</a>
+																							<a class="popup_menu_item tight" href="?l=norwegian">Norsk (Norwegian)</a>
+																							<a class="popup_menu_item tight" href="?l=polish">Polski (Polish)</a>
+																							<a class="popup_menu_item tight" href="?l=portuguese">Português (Portuguese)</a>
+																							<a class="popup_menu_item tight" href="?l=brazilian">Português-Brasil (Portuguese-Brazil)</a>
+																							<a class="popup_menu_item tight" href="?l=russian">Русский (Russian)</a>
+																							<a class="popup_menu_item tight" href="?l=romanian">Română (Romanian)</a>
+																							<a class="popup_menu_item tight" href="?l=schinese">简体中文 (Simplified Chinese)</a>
+																							<a class="popup_menu_item tight" href="?l=spanish">Español (Spanish)</a>
+																							<a class="popup_menu_item tight" href="?l=swedish">Svenska (Swedish)</a>
+																							<a class="popup_menu_item tight" href="?l=tchinese">繁體中文 (Traditional Chinese)</a>
+																							<a class="popup_menu_item tight" href="?l=thai">ไทย (Thai)</a>
+																							<a class="popup_menu_item tight" href="?l=turkish">Türkçe (Turkish)</a>
+																							<a class="popup_menu_item tight" href="?l=ukrainian">Українська (Ukrainian)</a>
+														<a class="popup_menu_item tight" href="http://translation.steampowered.com" target="_blank">Help us translate Steam</a>
+						</div>
+					</div>
+							</div>
+		</div>
+			</div>
+</div><div id="game_background_holder"><div id="game_background" style="background-image: url(http://cdn.akamai.steamstatic.com/steam/apps/247080/page.bg.jpg?t=1406743038);"></div></div><div id="store_header">
+	<div class="content">
+		<div id="store_controls">
+			<div id="cart_status_data">
+																<div class="store_header_btn_green store_header_btn" id="store_header_cart_btn" style="display: none;">
+					<div class="store_header_btn_caps store_header_btn_leftcap"></div>
+					<div class="store_header_btn_caps store_header_btn_rightcap"></div>
+					<a id="cart_link" class="store_header_btn_content" href="http://store.steampowered.com/cart/?snr=1_5_9__12">
+						Cart						(<span id="cart_item_count_value">0</span>)
+					</a>
+				</div>
+							</div>
+		</div>
+				<div id="store_nav_area">
+			<div class="store_nav_leftcap"></div>
+			<div class="store_nav_bg">
+				<div class="store_nav">
+					<a class="tab " href="http://store.steampowered.com/?snr=1_5_9__12">
+								<span>Featured Items					</a>
+										<div class="tab  flyout_tab" id="genre_tab" onmouseover="FlyoutMenu( 'genre_tab', 'genre_flyout', 'left', 'bottom' );" onmouseout="HideFlyoutMenu( event, 'genre_tab', 'genre_flyout' );">
+						<span class="pulldown">Games<span ></span></span>
+
+					</div>
+					<div class="popup_block_new flyout_tab_flyout" id="genre_flyout" style="display: none;" onmouseout="HideFlyoutMenu( event, 'genre_tab', 'genre_flyout' );">
+						<div class="popup_body popup_menu">
+																						<a class="popup_menu_item" href="http://store.steampowered.com/genre/Free%20to%20Play/?snr=1_5_9__12">
+									Free to Play								</a>
+																																																																																																																																																																																																																																																																																																																						<a class="popup_menu_item" href="http://store.steampowered.com/genre/Early%20Access/?snr=1_5_9__12">
+									Early Access								</a>
+																						<div class="hr"></div>
+							<div class="popup_menu_subheader">Browse by genre:</div>
+																																							<a class="popup_menu_item" href="http://store.steampowered.com/genre/Action/?snr=1_5_9__12">
+										Action									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Adventure/?snr=1_5_9__12">
+										Adventure									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Strategy/?snr=1_5_9__12">
+										Strategy									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/RPG/?snr=1_5_9__12">
+										RPG									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Indie/?snr=1_5_9__12">
+										Indie									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Massively%20Multiplayer/?snr=1_5_9__12">
+										Massively Multiplayer									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Casual/?snr=1_5_9__12">
+										Casual									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Simulation/?snr=1_5_9__12">
+										Simulation									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Racing/?snr=1_5_9__12">
+										Racing									</a>
+																																<a class="popup_menu_item" href="http://store.steampowered.com/genre/Sports/?snr=1_5_9__12">
+										Sports									</a>
+																																																																																																																																																																																											<div class="hr"></div>
+							<div class="popup_menu_subheader">
+								<div class="popup_menu_hint" data-store-tooltip="This list was created from the most popular tags assigned to games by the community.  Click for more details.">(<a href="http://store.steampowered.com/tag/">?</a>)</div>
+								Browse by tag:							</div>
+							<a class="popup_menu_item" href="http://store.steampowered.com/tag/browse/?snr=1_5_9__12">
+								See popular tags							</a>
+							<div class="hr"></div>
+							<div class="popup_menu_subheader">Browse by platform:</div>
+							<a class="popup_menu_item" href="http://store.steampowered.com/browse/mac/?snr=1_5_9__12">
+								Mac OS X							</a>
+							<a class="popup_menu_item" href="http://store.steampowered.com/browse/linux/?snr=1_5_9__12">
+								SteamOS + Linux							</a>
+						</div>
+					</div>
+										<a class="tab " href="http://store.steampowered.com/software/?snr=1_5_9__12">
+						<span>Software</span>
+					</a>
+					<a class="tab " href="http://store.steampowered.com/freestuff/demos/?snr=1_5_9__12">
+						<span>Demos</span>
+					</a>
+
+					<a class="tab " href="http://store.steampowered.com/news/?snr=1_5_9__12">
+						<span>News</span>
+					</a>
+
+
+											<a class="tab " href="http://store.steampowered.com/recommended/?snr=1_5_9__12">
+							<span>Recommended</span>
+						</a>
+					
+					<div id="store_search">
+						<form id="searchform" name="searchform" method="get" action="http://store.steampowered.com/search/" onsubmit="return SearchSuggestCheckTerm(this);">
+							<input type="hidden" name="snr" value="1_5_9__12" >
+							<div class="searchbox">
+								<input id="store_nav_search_term" name="term" type="text" class="default" value="search the store" size="22" autocomplete="off">
+								<a href="#" id="store_search_link" onclick="var form = $(this).up('form'); if ( form.onsubmit() ) form.submit(); return false;"><img src="http://store.akamai.steamstatic.com/public/images/blank.gif"></a>
+							</div>
+						</form>
+					</div>
+					<div id="searchterm_options" class="search_suggest popup_block_new" style="display: none;">
+						<div class="popup_body" style="border-top: none;">
+							<div id="search_suggestion_contents">
+							</div>
+						</div>
+					</div>
+					<script language="JavaScript">
+						$J( function() { EnableSearchSuggestions( $('searchform').elements['term'], '1_5_9_', 'CA', 'english', '623367' ); } );
+					</script>
+
+				</div>
+			</div>
+			<div class="store_nav_rightcap"></div>
+		</div>
+			</div>
+</div>
+<script type="text/javascript">
+	var g_AccountID = 0;
+	var g_sessionID = "MjExMzg5NzM0MQ==";
+	var g_ServerTime = 1406761727;
+
+	$J( InitMiniprofileHovers );
+
+	</script>
+<!-- Main Background -->
+<div id="main">
+
+
+	<div id="main_content" itemscope itemtype="http://schema.org/Product">
+		<meta itemprop="image" content = "http://cdn.akamai.steamstatic.com/steam/apps/247080/capsule_231x87.jpg?t=1406743038"/>
+		<div class="page_title_area game_title_area">
+			<div class="breadcrumbs">
+								<div class="blockbg">
+											<a href="http://store.steampowered.com/search/?term=&snr=1_5_9__205">All Games</a>
+																					&gt; <a href="http://store.steampowered.com/genre/RPG/?snr=1_5_9__205">RPG Games</a>
+															&gt; <a href="http://store.steampowered.com/app/247080/?snr=1_5_9__205"><span itemprop="name">Crypt of the NecroDancer</span></a>
+
+				</div>
+				<div style="clear: left;"></div>
+							</div>
+            <div class="apphub_HomeHeaderContent">
+
+	<div class="apphub_HeaderStandardTop">
+				<div class="apphub_OtherSiteInfo">
+			<a class="btn_darkblue_white_innerfade btn_medium" href="http://steamcommunity.com/app/247080" onclick="if ( typeof _gaq != 'undefined' && _gaq ) { _gaq.push(['app._link', 'http://steamcommunity.com/app/247080']); return false;">
+				<span>Community Hub</span>
+			</a>
+		</div>
+		<div class="apphub_AppIcon"><img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/apps/247080/d6b5298b33cb990dcbb3fae94db4b421b813a724.jpg"><div class="overlay"></div></div>
+		<div class="apphub_AppName">Crypt of the NecroDancer</div>
+		<div style="clear: both"></div>
+	</div>
+
+</div>
+
+		</div>
+
+		<div class="block">
+						<script type="text/javascript">
+				var strRequiredVersion = "9";
+				if ( typeof( g_bIsOnMac ) != 'undefined' && g_bIsOnMac )
+					strRequiredVersion = "10.1.0";
+
+				
+				var bShouldUseHTML5 = !swfobject.hasFlashPlayerVersion(strRequiredVersion) || BDoesUserPreferHTML5();
+			</script>
+			<div class="block_content" id="game_highlights">
+				<div class="leftcol">
+					<div class="highlight_ctn">
+						<div class="highlight_overflow">
+							<div id="highlight_player_area" >
+																	<div class="highlight_player_item highlight_movie" id="highlight_movie_2033530" style="display: none;">
+										<script type="text/javascript">
+											if( bShouldUseHTML5 )
+											{
+												document.write('<video class="highlight_player_item highlight_movie" src="http://cdn.akamai.steamstatic.com/steam/apps/2033530/movie480.webm?t=1406698608" data-hd-src="http://cdn.akamai.steamstatic.com/steam/apps/2033530/movie_max.webm?t=1406698608" poster="http://cdn.akamai.steamstatic.com/steam/apps/2033530/movie.293x165.jpg?t=1406698608" id="movie_2033530" ><p>You will need to <a href="http://www.adobe.com/go/getflashplayer" target="_blank">Install</a> the latest Flash plugin to view this page properly.</p></video>');
+												jQuery("#movie_2033530").videoControls();
+											}
+											else
+												document.write('<div id="movie_2033530" class="highlight_flash_player_notice" style="display: none;"><p>You will need to <a href="http://www.adobe.com/go/getflashplayer" target="_blank">Install</a> the latest Flash plugin to view this page properly.</p></div>');
+										</script>
+									</div>
+								
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_43a777dbe156663c772630141c08fd1025fa7d3f.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_43a777dbe156663c772630141c08fd1025fa7d3f.1920x1080.jpg?t=1406743038"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_1ab8eec24228ca8a752d5f58562593cd3594ed75.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_1ab8eec24228ca8a752d5f58562593cd3594ed75.1920x1080.jpg?t=1406743038"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_f959c35787f5e293a90266e53ac3cc375dff3b4b.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_f959c35787f5e293a90266e53ac3cc375dff3b4b.1920x1080.jpg?t=1406743038"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_f2fb5cacd9fdc9b4fec887859857905e6fe7ad72.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_f2fb5cacd9fdc9b4fec887859857905e6fe7ad72.1920x1080.jpg?t=1406743038"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																	<div class="highlight_player_item highlight_screenshot" id="highlight_screenshot_ss_ff830bbd769809ea5d81a1c463df6b9d8c2a5a28.jpg" style="display: none;">
+										<div class="screenshot_holder">
+											<a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_ff830bbd769809ea5d81a1c463df6b9d8c2a5a28.1920x1080.jpg?t=1406743038"">
+												<img src="http://store.akamai.steamstatic.com/public/images/blank.gif">
+											</a>
+										</div>
+									</div>
+																<script type="text/javascript">
+									var rgMovieFlashvars = {
+																					'movie_2033530': {
+										        FILENAME: "http://cdn.akamai.steamstatic.com/steam/apps/2033530/movieLrg.flv?t=1406698608",
+										        MOVIE_NAME: "Early+Access+Trailer"
+										     },
+																				'' : ''
+									};
+									var rgCommonFlashVars = {
+											clientLanguage: "english",
+											capsuleSize: "huge",
+											STAGE_WIDTH: 600,
+											STAGE_HEIGHT: 338,
+									        AUTO_PLAY: "true",
+									        ALLOW_JSPAUSE: "true",
+								        	TRACK_MUTE: "true",
+								        	CHECKBOX_AUTOPLAY_SHOW: "true",
+								        	CHECKBOX_AUTOPLAY_TEXT: "Autoplay+videos"
+									};
+									var rgScreenshotURLs = {
+																					'ss_43a777dbe156663c772630141c08fd1025fa7d3f.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_43a777dbe156663c772630141c08fd1025fa7d3f.600x338.jpg?t=1406743038',
+																					'ss_1ab8eec24228ca8a752d5f58562593cd3594ed75.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_1ab8eec24228ca8a752d5f58562593cd3594ed75.600x338.jpg?t=1406743038',
+																					'ss_f959c35787f5e293a90266e53ac3cc375dff3b4b.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_f959c35787f5e293a90266e53ac3cc375dff3b4b.600x338.jpg?t=1406743038',
+																					'ss_f2fb5cacd9fdc9b4fec887859857905e6fe7ad72.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_f2fb5cacd9fdc9b4fec887859857905e6fe7ad72.600x338.jpg?t=1406743038',
+																					'ss_ff830bbd769809ea5d81a1c463df6b9d8c2a5a28.jpg' : 'http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_ff830bbd769809ea5d81a1c463df6b9d8c2a5a28.600x338.jpg?t=1406743038',
+																				'' : ''
+									};
+								</script>
+							</div>
+														<div id="highlight_strip">
+								<div id="highlight_strip_scroll" style="width: 722px;">
+									<div class="highlight_selector"></div>
+
+																			<div class="highlight_strip_item highlight_strip_movie" id="thumb_movie_2033530" >
+											<img class="movie_thumb" src="http://cdn.akamai.steamstatic.com/steam/apps/2033530/movie.184x123.jpg?t=1406698608">
+											<div class="highlight_movie_marker"></div>
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_43a777dbe156663c772630141c08fd1025fa7d3f.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_43a777dbe156663c772630141c08fd1025fa7d3f.116x65.jpg?t=1406743038">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_1ab8eec24228ca8a752d5f58562593cd3594ed75.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_1ab8eec24228ca8a752d5f58562593cd3594ed75.116x65.jpg?t=1406743038">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_f959c35787f5e293a90266e53ac3cc375dff3b4b.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_f959c35787f5e293a90266e53ac3cc375dff3b4b.116x65.jpg?t=1406743038">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_f2fb5cacd9fdc9b4fec887859857905e6fe7ad72.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_f2fb5cacd9fdc9b4fec887859857905e6fe7ad72.116x65.jpg?t=1406743038">
+										</div>
+																			<div class="highlight_strip_item highlight_strip_screenshot" id="thumb_screenshot_ss_ff830bbd769809ea5d81a1c463df6b9d8c2a5a28.jpg" >
+											<img src="http://cdn.akamai.steamstatic.com/steam/apps/247080/ss_ff830bbd769809ea5d81a1c463df6b9d8c2a5a28.116x65.jpg?t=1406743038">
+										</div>
+																	</div>
+							</div>
+															<div>
+									<div class="slider" id="highlight_slider" >
+										<div class="slider_bg">
+										</div>
+										<div class="handle">
+										</div>
+									</div>
+								</div>
+								<script type="text/javascript">
+
+									Event.observe( document, 'dom:loaded', function() {
+										new HighlightPlayer( {
+											elemPlayerArea: 'highlight_player_area',
+											elemStrip: 'highlight_strip',
+											elemStripScroll: 'highlight_strip_scroll',
+											elemSlider: 'highlight_slider',
+											rgMovieFlashvars: rgMovieFlashvars,
+											rgScreenshotURLs: rgScreenshotURLs,
+											rgDefaultMovieFlashvars: rgCommonFlashVars,
+											bUseHTMLPlayer: bShouldUseHTML5
+										} );
+									} );
+
+								</script>
+													</div>
+					</div>
+				</div>
+				<div class="rightcol">
+					<div class="glance_ctn">
+						<div class="game_header_image_ctn">
+							<img class="game_header_image" src="http://cdn.akamai.steamstatic.com/steam/apps/247080/header_292x136.jpg?t=1406743038">
+						</div>
+													<div class="game_description_snippet">
+								Crypt of the NecroDancer is a hardcore roguelike rhythm game. Can you survive this deadly dungeon of dance? Groove to the epic Danny Baranowsky soundtrack, or select songs from your own MP3 collection!							</div>
+						
+													<div class="inner_rule small_margin"></div>
+															<div>
+									Release Date: 30 Jul 2014								</div>
+																						<!-- when the javascript runs, it will set these visible or not depending on what fits in the area -->
+								<div class="glance_tags_ctn">
+									<div class="glance_tags_label">Popular user-defined tags for this product:</div>
+									<div class="glance_tags popular_tags" data-appid="247080">
+																																	<a href="http://store.steampowered.com/tag/en/Rogue-like/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Rogue-like												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Rhythm/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Rhythm												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Great%20Soundtrack/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Great Soundtrack												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Female%20Protagonist/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Female Protagonist												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Indie/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Indie												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Pixel%20Graphics/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Pixel Graphics												</a>
+																																												<a href="http://store.steampowered.com/tag/en/RPG/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													RPG												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Hardcore/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Hardcore												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Early%20Access/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Early Access												</a>
+																																												<a href="http://store.steampowered.com/tag/en/Dungeon%20Crawler/?snr=1_5_9__409" class="app_tag" style="display: none;">
+													Dungeon Crawler												</a>
+																															<div class="app_tag add_button" onclick="ShowAppTagModal( 247080 )">+</div>
+									</div>
+								</div>
+																				
+						
+							<a class="linkbar" href="http://store.steampowered.com/video/247080?snr=1_5_9__400">
+								<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_trailers.png"></div>
+																	Watch HD video															</a>
+
+						
+					</div>
+				</div>
+				<div style="clear: both;"></div>
+			</div>
+								</div>
+
+		
+		<div class="leftcol game_description_column">
+
+			
+				<div class="early_access_header">
+					<div class="heading">
+						<h1 class="inset">Early Access Game</h1>
+						<h2 class="inset">Get instant access and start playing; get involved with this game as it develops.</h2>
+						<p><span>Note:</span> This Early Access game may or may not change significantly over the course of
+									development. If you are not excited to play this game in its current state, then you
+									may want to wait until the game progresses further in development. <a href="http://store.steampowered.com/earlyaccessfaq/?snr=1_5_9_">Learn more</a></p>
+					</div>
+					<div class="devnotes">
+														<div class="devs_say">What the developers have to say:</div>
+							<div id="devnotes_expander">
+								<h1>Why Early Access?</h1>
+								&ldquo;Earlier in the year we released an alpha build to everyone who pre-ordered, and the feedback we received on that build helped us to <i>vastly</i> improve the game. We're excited to release via Early Access because we know <strong>Crypt of the NecroDancer</strong> is going to improve greatly as a result.  Our community is amazing!&rdquo;
+
+								<h1>How long will this game be in Early Access?</h1>
+								&ldquo;We plan to finish zone 4 and the final bosses in 2014.  However, if the game proves to be popular we hope to continue to add additional features beyond that.  We are having a great time developing this game and we want to keep on improving it!&rdquo;
+
+								<h1>How is the full version planned to differ from the Early Access version?</h1>
+								&ldquo;The full version will include zone 4, the final boss battles, as well as more playable characters.&rdquo;
+
+								<h1>What is the current state of the Early Access version?</h1>
+								&ldquo;The current version includes zones 1, 2, and 3.  It also includes 4 of the 8 playable characters.  Many fans have racked up hundreds of hours of playtime already, so there's no shortage of fun to be had with this current version!&rdquo;
+
+								<h1>Will the game be priced differently during and after Early Access?</h1>
+								&ldquo;The game's price will not change.&rdquo;
+
+								<h1>How are you planning on involving the Community in your development process?</h1>
+								&ldquo;We've already taken many suggestions from the community and incorporated them in the game.  By expanding our community via Early Access we look forward to doing this even more!&rdquo;
+
+														</div> <!-- /devnotes_expander -->
+						<a class="morebutton" id="devnotes_more" href="#"  onclick="$J('#devnotes_expander').css({'max-height': 'none'}); $J(this).hide(); return false;">Read more</a>
+					</div>
+				</div>
+
+			
+						<div id="game_area_purchase">
+								
+
+								
+								
+				<!--[if lte IE 7]>
+<style type="text/css">
+.game_area_purchase_game_dropdown_right_panel .btn_addtocart { float: none; }
+</style>
+<![endif]-->
+<div class="game_area_purchase_game_wrapper">
+		<div class="game_area_purchase_game">
+		<form name="add_to_cart_47831" action="http://store.steampowered.com/cart/" method="POST">
+			<input type="hidden" name="snr" value="1_5_9__403">
+			<input type="hidden" name="action" value="add_to_cart">
+			<input type="hidden" name="sessionid" value="MjExMzg5NzM0MQ==">
+			<input type="hidden" name="subid" value="47831">
+		</form>
+				<div class="game_area_purchase_platform"><span class="platform_img steamplay"></span><span class="platform_img win"></span><span class="platform_img mac"></span><span class="platform_img linux"></span></div>
+		<h1>Buy Crypt of the NecroDancer</h1>
+						
+		
+		<div class="game_purchase_action" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+						<div class="game_purchase_action_bg">
+																			<div class="game_purchase_price price"  itemprop="price">
+							&#36;14.99 USD						</div>
+													<div class="btn_addtocart">
+					<div class="btn_addtocart_left"></div>
+					 
+						<a class="btn_addtocart_content" href="javascript:addToCart( 47831);">Add to Cart</a>
+										<div class="btn_addtocart_right"></div>
+				</div>
+							</div>
+		</div>
+	</div>
+	</div>
+<div class="game_area_purchase_game_wrapper">
+		<div class="game_area_purchase_game">
+		<form name="add_to_cart_47832" action="http://store.steampowered.com/cart/" method="POST">
+			<input type="hidden" name="snr" value="1_5_9__403">
+			<input type="hidden" name="action" value="add_to_cart">
+			<input type="hidden" name="sessionid" value="MjExMzg5NzM0MQ==">
+			<input type="hidden" name="subid" value="47832">
+		</form>
+				<div class="game_area_purchase_platform"><span class="platform_img steamplay"></span><span class="platform_img win"></span><span class="platform_img mac"></span><span class="platform_img linux"></span></div>
+		<h1>Buy Crypt of the NecroDancer + Soundtrack</h1>
+						
+		
+		<div class="game_purchase_action">
+						<div class="game_purchase_action_bg">
+																			<div class="game_purchase_price price" >
+							&#36;24.99 USD						</div>
+													<div class="btn_addtocart">
+					<div class="btn_addtocart_left"></div>
+					 
+						<a class="btn_addtocart_content" href="javascript:addToCart( 47832);">Add to Cart</a>
+										<div class="btn_addtocart_right"></div>
+				</div>
+							</div>
+		</div>
+	</div>
+	</div>
+	<div class="game_area_dlc_section">
+		<h2 class="gradientbg">Downloadable Content For This Game</h2>		<form name="add_all_dlc_to_cart" action="http://store.steampowered.com/cart/?snr=1_5_9_" method="POST">
+			<input type="hidden" name="action" value="add_to_cart">
+
+			<div class="tableView">
+
+							<div class="gameDlcBlocks">
+			
+														<a class="game_area_dlc_row odd" id="dlc_row_314680" href="http://store.steampowered.com/app/314680/?snr=1_5_9__405" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':'314680','public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+
+						<div class="game_area_dlc_price">
+															N/A
+													</div>
+						<div class="game_area_dlc_name">
+							Crypt of the Necrodancer Soundtrack						</div>
+											</a>												</div>
+							
+			
+		</div> <!-- tableView -->
+
+		<div style="clear: right;"></div>
+
+		</form>
+
+	</div> <!-- game_area_dlc_section -->
+
+		
+			</div>
+			<!-- game_area_purchase -->
+
+		
+			
+			<!-- Discussions block -->
+
+			<div class="early_access_banner">
+				<div class="img"></div>
+
+				<a class="btn_darkblue_white_innerfade btn_border_2px btn_medium" href="http://steamcommunity.com/app/247080/discussions/">
+					<span>See all discussions</span>
+				</a>
+
+				<p>Report bugs and leave feedback for this game on the discussion boards</p>
+
+			</div>
+							<div id="game_area_reviews" class="game_area_description">
+					<h2>Reviews</h2>
+					<p>“Editor's Choice”<br><a target="_blank" href="http://destructoid.com/our-top-10-favorite-games-of-pax-prime-2013-261077.phtml/"  >Destructoid</a><br><br>“It's just so ingenious!”<br><a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://tinyurl.com/mda63hh/"  >Adam Sessler</a><br><br>“It's unlike anything I've played before and represents everything that I treasure about the indie games scene.”<br><a target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://www.joystiq.com/2013/08/31/pounding-beats-and-dragons-in-crypt-of-the-necrodancer/"  >Joystiq</a><br></p>
+				</div>
+					
+							<div id="game_area_description" class="game_area_description">
+				<h2>About the Game</h2>
+				Crypt of the NecroDancer is a hardcore roguelike rhythm game. Can you survive this deadly dungeon of dance, slay the NecroDancer, and recapture your still beating heart? Or will you be a slave to the rhythm for all eternity?<br><br><ul class="bb_ul"><li>Move on the beat to navigate <strong>ever changing dungeons</strong> while battling dancing skeletons, zombies, dragons, and more! <br></li><li>Groove to the game's epic <strong>Danny Baranowsky soundtrack</strong>, or select songs from <strong>your own MP3 collection</strong>!<br></li><li>Play with <strong>keyboard, controller, or even a USB dance pad</strong>!</li></ul>			</div>
+		
+						<div id="game_area_sys_req" class="game_area_description">
+					<h2>
+						<span class="platform_img win"></span> PC System Requirements					</h2>
+
+											<div id="game_area_sys_req_full">
+							<ul>
+								<strong>Minimum:</strong><br><ul class="bb_ul"><li><strong>OS:</strong> Windows XP</li></ul>							</ul>
+						</div>
+										
+					<div style="clear: both;"></div>
+				</div>
+									<div id="game_area_sys_req" class="game_area_description">
+					<h2>
+						<span class="platform_img mac"></span> Mac System Requirements					</h2>
+
+											<div id="game_area_sys_req_full">
+							<ul>
+								<strong>Minimum:</strong><br><ul class="bb_ul"><li><strong>OS:</strong> 10.6</li></ul>							</ul>
+						</div>
+										
+					<div style="clear: both;"></div>
+				</div>
+									<div id="game_area_sys_req" class="game_area_description">
+					<h2>
+						<span class="platform_img linux"></span> Linux System Requirements					</h2>
+
+											<div id="game_area_sys_req_full">
+							<ul>
+								<strong>Minimum:</strong><br><ul class="bb_ul"><li><strong>OS:</strong> Steam OS, or Ubuntu 12.04 or later</li></ul>							</ul>
+						</div>
+										
+					<div style="clear: both;"></div>
+				</div>
+					
+
+		
+		
+								<div class="block">
+				<div class="block_header">
+					<div class="right">
+						<a href="http://store.steampowered.com/recommended/morelike/app/247080/?snr=1_5_9__300">See all</a>
+					</div>
+					<h4>More like this</h4>
+				</div>
+				<div class="block_content nopad">
+											<a class="small_cap" href="http://store.steampowered.com/app/248820/?snr=1_5_9__300" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':248820,'public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+							<img class="small_cap_img" src="http://cdn.akamai.steamstatic.com/steam/apps/248820/capsule_184x69.jpg?t=1392098417" border="0" width="184" height="69"/>
+							<h4>Risk of Rain</h4>
+															<h5>&#36;9.99 USD</h5>
+													</a>
+											<a class="small_cap" href="http://store.steampowered.com/app/268750/?snr=1_5_9__300" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':268750,'public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+							<img class="small_cap_img" src="http://cdn.akamai.steamstatic.com/steam/apps/268750/capsule_184x69.jpg?t=1402446465" border="0" width="184" height="69"/>
+							<h4>Magicite</h4>
+															<h5>&#36;9.99 USD</h5>
+													</a>
+											<a class="small_cap" href="http://store.steampowered.com/app/63710/?snr=1_5_9__300" onmouseover="GameHover( this, event, $('global_hover'), {'type':'app','id':'63710','public':1} );" onmouseout="HideGameHover( this, event, $('global_hover') )">
+							<img class="small_cap_img" src="http://cdn.akamai.steamstatic.com/steam/apps/63710/capsule_184x69.jpg?t=1375984230" border="0" width="184" height="69"/>
+							<h4>BIT.TRIP RUNNER</h4>
+															<h5>&#36;9.99 USD</h5>
+													</a>
+										<div style="clear: left;"></div>
+				</div>
+			</div>
+					
+		<script>
+	jQuery( document ).ready(function( $ ) {
+		CollapseLongReviews();
+	});
+</script>
+	<div class="user_reviews_header no_bottom_margin">
+		Helpful customer reviews				<div class="user_reviews_see_all">
+			<a href="http://store.steampowered.com/reviews/?snr=1_5_9_">About Reviews</a>
+		</div>
+			</div>
+	<div class="user_reviews_filter_bar">
+		<span class="user_reviews_filter_text">Filter:</span>
+		<div class="user_reviews_tab active" id="ReviewsTab_all">
+			<a href="javascript:void(0)" onclick="SelectReviews( 247080, 'all', 9223372036854775807, 'english' );">
+				<span>Most helpful</span>
+			</a>
+		</div>
+		<div class="user_reviews_tab" id="ReviewsTab_positive">
+			<a href="javascript:void(0)" onclick="SelectReviews( 247080, 'positive', 9223372036854775807, 'english' );">
+				<span>Only positive</span>
+			</a>
+		</div>
+		<div class="user_reviews_tab" id="ReviewsTab_negative">
+			<a href="javascript:void(0)" onclick="SelectReviews( 247080, 'negative', 9223372036854775807, 'english' );">
+				<span>Only negative</span>
+			</a>
+		</div>
+		<div style="clear: left;"></div>
+	</div>
+
+	<div id="LoadingMoreReviewspositive" style="display: none" class="loading_more_reviews">
+		<img src="http://store.akamai.steamstatic.com/public/shared/images/throbber.gif" class="loading_more_reviews_throbber">
+		Loading reviews...	</div>
+	<div id="LoadingMoreReviewsnegative" style="display: none" class="loading_more_reviews">
+		<img src="http://store.akamai.steamstatic.com/public/shared/images/throbber.gif" class="loading_more_reviews_throbber">
+		Loading reviews...	</div>
+
+	<div id="Reviews_positive" style="display: none" class="user_reviews_container"></div>
+	<div id="Reviews_negative" style="display: none" class="user_reviews_container"></div>
+	<div id="Reviews_all" class="user_reviews_container">
+			<div id="Reviewsall0">
+			<div class="review_box">
+						<div class="header">
+				67 of 76 people (88%) found this review helpful								<div class="commentCount"><a href="http://steamcommunity.com/id/CueZero/recommended/247080/">8 <img src="http://store.akamai.steamstatic.com/public/shared/images/comment_quoteicon.png" align="center"></a></div>
+							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11480576">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/CueZero/">
+						<div class="playerAvatar in-game">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/a4/a4787ff73f549c8f25c83ee9d9f9ca6302ee1bd1.jpg" data-miniprofile="41242226">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/CueZero/" data-miniprofile="41242226">CueZero</a></div>
+								<div class="num_owned_games">1,154 products in account</div>
+												<div class="num_reviews">27 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/CueZero/recommended/247080/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/CueZero/recommended/247080/">Recommended</a></div>
+										<div class="hours">20.4 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					<i>&quot;Kick! Punch! It's all in the mind.&quot;</i><br><br>These words were spoken by the great Tamanegi Sensei (better known as Chop Chop Master Onion) over 15 years ago when music-based games were first making a name, and they ring even truer today as the rhythm genre takes an evolutionary step into the dungeon crawling arena.<br><br><i>NecroDancer</i> is the holy matrimony between addictive rhythm game grooviness and challenging roguelike complexity, and I'll be damned if it doesn't hit the spot. It's amazing that a concept this unique took as long as it did to come to fruition, but it's been more than worth the wait.<br><br>Not only is the concept unique but it's done <b>right</b>, something we hardly ever see when a new mechanic or gimmick is introduced to the gaming world for the first time. We see so many &quot;new&quot; ideas that are merely just a melting pot of previously established genres. Lo and behold, these developers have obviously set out to refine and perfect their concoction of varied gameplay elements on their first attempt and that is highly admirable. <i>Necrodancer</i> stands not only as a magnificently well-realized combination of genres but as a completely new experience of it's <b>own</b> and the start of what is hopefully a new trend of taking fun and risky chances in game development.<br><br>The in-game music is dark, fantastic and quite danceable itself lending to the blissful feeling of hitting each beat of the song with perfect timing. The precision of the music-based movement has lead lots of early adopters of the game to swear by playing with DDR dancepads which apparently add a lot to the fun and engaging nature of exploring the Crypt. This shows a serious level of dedication from the rhythm game community and has already garnered enough attention to spawn it's own design of custom <a class="bb_link" target="_blank" href="https://steamcommunity.com/linkfilter/?url=http://necrodancer.com/dancepads.php" ><i>NecroDancer</i> dancepads</a>.<br><br>And if you somehow are crazy enough to get tired of renowned composer Danny Baranowsky's heavy electronic horror jams, the game features an intuitive beat detection function for usage of songs from your own library. The detection of beats in your songs is generally spot on, and makes trying and discovering those perfect tunes for the game infinitely explorable and replayable for audiophiles in the same way games like <i>Audiosurf</i> and <i>Beat Hazard Ultra</i> provide endless entertainment. Even for those songs that might be a bit too fast or slow for manageable NecroDancing, there's a feature to alter the speed of in-game beats to give more accessibility for a wider range of genres. <i>No form of music shall go undanced in the heart of these Crypts</i>.<br><br>There are four main floors to the game with three levels and a boss-type enemy each, but beating any single one of them won't be an easy task. You will retry many times being forced to scour every diamond, buy up all the upgrades, and loot your way through multiple plays before you succeed, but what makes this so much more of a pleasure to replay than any other games which borrow rogue elements is the musical nature of the game. <i>NecroDancer</i> replaces the repetitive and stale turn-based combat of traditional roguelikes with the fun and engaging audio interaction of the best rhythm games made to date.<br><br>With a touch of the strategic approach of traditional tactics games, the enemies each have a very distinct pattern to their movements and attacks that the player must learn through multiple failures and awareness. Starting out you encounter the easier monsters such as slimes that move passively back and forth as well as skeletons that follow behind in a predictable way that is easy to counter. Protecting the exit of each floor are the harder and more complex mini-bosses, ranging from hulking Minotaurs that charge towards you in a straight path or determined Dragons that you must outsmart and keep just out of harm's way in order to retain your doomed life just a little longer.<br><br>Throughout your journeys into the crypt you'll have two different forms of currency, first being gold coins that you can spend within the levels at merchants on equipment and items to help you on your current run. Second, and most importantly are the much harder to find Diamonds which are the only thing that carry over into the lobby after death, allowing you to purchase upgrades to the gear and loot you come across during your runs. This adds an insanely addictive level of persistence in the same way that the character growth in <i>Rogue Legacy</i> or shortcut system of <i>Spelunky</i> do.<br><br>The shops you purchase these upgrades from won't be made available to you that easily, however, as each of the different merchants and trainers you need will be imprisoned and strewn about the various dungeons forcing you to dance deeper and deeper to rescue the people you will rely on in the future. The game is hard and you'll die many times, but the deeper you go the more you discover, and the more you discover the easier your respective trips will become. This adds a ridiculous amount of replayability and persistence to an already engaging and genre defying new formula.<br><br>Here I am hopping and slashing away to the beat of <i>Castlevania</i>'s 'Vampire Killer', and I come across a Blood Whip. Things could not be more perfect. Necrodancer isn't just a gimmick, it's the start of something beautiful, it's a new kind of entertainment that can be enjoyed from the hardecore-est of dungeon delving roguelite aficionados to the most casual of rhythm game fans, but there is one thing that all of these demographics must have in common; <u>a love and dedication for the culture of music</u>					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11480576', 'all' ); return false;">Read More</a></div>
+					Posted: 30 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11480576' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11480576"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11480576' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11480576"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				33 of 43 people (77%) found this review helpful							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11477320">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/feeblethemighty/">
+						<div class="playerAvatar offline">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/1d/1d06e7796b7306809703567f36e3070713500679.jpg" data-miniprofile="70249718">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/feeblethemighty/" data-miniprofile="70249718">Feeblethemighty</a></div>
+								<div class="num_owned_games">141 products in account</div>
+												<div class="num_reviews">1 review</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/feeblethemighty/recommended/247080/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/feeblethemighty/recommended/247080/">Recommended</a></div>
+										<div class="hours">54.0 hrs on record</div>
+									</div>
+
+									<div class="early_access_review tooltip" data-tooltip-content="This review was written while Crypt of the NecroDancer was marked as Steam Early Access">Early Access Review</div>
+				
+				<div class="content">
+					Every move is on the beat, every move is a tiny puzzle!  You gotta know each enemy's pattern, know where they will move next beat, and make lighting quick decisions in order to survive.  This game gets bonus points for solving the traditional turn-based roguelike conundrum of how to implement local multiplayer.  Co-op FTW!<br><br>So many game modes, but I play this game everyday for the procedurally generated daily challenges.  So addictive!					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11477320', 'all' ); return false;">Read More</a></div>
+					Posted: 30 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11477320' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11477320"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11477320' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11477320"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				38 of 57 people (67%) found this review helpful							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11465415">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/plasmaman2/">
+						<div class="playerAvatar in-game">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/58/581ac76b73af3e70028ecee6cc154a5a98be0a31.jpg" data-miniprofile="67563275">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/plasmaman2/" data-miniprofile="67563275">Rust</a></div>
+								<div class="num_owned_games">101 products in account</div>
+												<div class="num_reviews">3 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/plasmaman2/recommended/247080/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/plasmaman2/recommended/247080/">Recommended</a></div>
+										<div class="hours">15.0 hrs on record</div>
+									</div>
+
+									<div class="early_access_review tooltip" data-tooltip-content="This review was written while Crypt of the NecroDancer was marked as Steam Early Access">Early Access Review</div>
+				
+				<div class="content">
+					I can reccomend this game to anyone who likes rouge likes and rhythm games, because of its A+ soundtrack composed by dannyB, but i dont need to sing his praises. The game controlls wonderfully. you can play with a DDR pad if you want aswell!<br><br>So over all i would have to give this game a 10/10, for the wonderfully composed music and how wonderful it feels to deliver beat downs to the beat.					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11465415', 'all' ); return false;">Read More</a></div>
+					Posted: 29 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11465415' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11465415"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11465415' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11465415"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				21 of 33 people (64%) found this review helpful							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11472560">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/willthgreat/">
+						<div class="playerAvatar in-game">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/ac/accb5087166a670d22ca3d9f1de943245312d9ea.jpg" data-miniprofile="61475642">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/willthgreat/" data-miniprofile="61475642">WillThGreat</a></div>
+								<div class="num_owned_games">248 products in account</div>
+												<div class="num_reviews">5 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/willthgreat/recommended/247080/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/willthgreat/recommended/247080/">Recommended</a></div>
+										<div class="hours">9.9 hrs on record</div>
+									</div>
+
+									<div class="early_access_review tooltip" data-tooltip-content="This review was written while Crypt of the NecroDancer was marked as Steam Early Access">Early Access Review</div>
+				
+				<div class="content">
+					Crypt of the NecroDancer is an extremely fun and unique take on the genre. I've put several hours into this game and have only completed the first two zones. This is probably due to my lack of skill more so than the difficulty itself. That being said, the game is very difficult, especially as you enter later zones. <br><br>This is one of the few games I'd recommend in its current state, regardless of whether or not it's in Early Access. There's enough content currently in the game to play for hundreds of hours.					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11472560', 'all' ); return false;">Read More</a></div>
+					Posted: 29 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11472560' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11472560"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11472560' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11472560"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				11 of 17 people (65%) found this review helpful							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11480454">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/biggiantcircles/">
+						<div class="playerAvatar offline">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/eb/eb43c8880c6daba37902e43d336fa593a4e60fea.jpg" data-miniprofile="2151200">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/biggiantcircles/" data-miniprofile="2151200">bgc</a></div>
+								<div class="num_owned_games">406 products in account</div>
+												<div class="num_reviews">2 reviews</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/biggiantcircles/recommended/247080/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/biggiantcircles/recommended/247080/">Recommended</a></div>
+										<div class="hours">24.6 hrs on record</div>
+									</div>
+
+				
+				<div class="content">
+					By the time I was done playing this, I'd grown three more sets of balls. I ain't even mad.<br><br>11/10 would play again.  Right now, actually.					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11480454', 'all' ); return false;">Read More</a></div>
+					Posted: 30 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11480454' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11480454"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11480454' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11480454"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+		<div class="review_box">
+						<div class="header">
+				120 of 129 people (93%) found this review helpful							</div>
+					<div style="clear: left;"></div>
+
+		<div id="ReviewContentall11439950">
+			<div class="leftcol">
+				<div class="avatar">
+					<a href="http://steamcommunity.com/id/haughington/">
+						<div class="playerAvatar offline">
+														<img src="http://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/13/134d815a0caec672680d0d5bd7e6a548c9ba2cf5.jpg" data-miniprofile="90176991">
+						</div>
+					</a>
+				</div>
+				<div class="persona_name"><a href="http://steamcommunity.com/id/haughington/" data-miniprofile="90176991">Haughington</a></div>
+								<div class="num_owned_games">235 products in account</div>
+												<div class="num_reviews">1 review</div>
+							</div>
+
+			<div class="rightcol">
+				<div class="vote_header">
+					<div class="thumb">
+						<a href="http://steamcommunity.com/id/haughington/recommended/247080/"><img src="http://store.akamai.steamstatic.com/public/shared/images/userreviews/icon_thumbsUp.png" width="44" height="44"></a>
+					</div>
+
+					<div class="title"><a href="http://steamcommunity.com/id/haughington/recommended/247080/">Recommended</a></div>
+										<div class="hours">300.6 hrs on record</div>
+									</div>
+
+									<div class="early_access_review tooltip" data-tooltip-content="This review was written while Crypt of the NecroDancer was marked as Steam Early Access">Early Access Review</div>
+				
+				<div class="content">
+					I've been playing this game obsessively for a couple months now, and still can't get enough of it.  Learning the patterns of all the enemies is one of the most satisfying things I've ever done in any game.  When you start out, you're just fumbling around, faceplanting into enemies and getting torn apart.  If you practice enough, though, you'll be able to take on any situation without suffering so much as a scratch.  Every part of the game is very doable with the default equipment, so you're never just screwed because the right items didn't drop for you.  The weapons and spells that you can find all work differently and cause you to change your method of attack, but they're all pretty balanced.  There are a ton of different weapons types with their own unique advantages and drawbacks, rather than traditional &quot;tiers&quot; of weapons (1 damage, 2 damage, 3 damage, etc.)  And there's an instant replay feature upon death, where you can look and see what you could have done differently to save yourself (there's always SOMETHING).  This is quite possibly the most well-balanced game I've ever played, and I adore it.  Pick this game up right now if you can.<br><br>Edit: If you have any doubts, just look at how many hours I've logged on it ;)					<div class="gradient"></div>
+				</div>
+
+				<div class="posted">
+					<div class="view_more"><a href="#" onclick="UserReviewShowMore('11439950', 'all' ); return false;">Read More</a></div>
+					Posted: 27 July 2014									</div>
+
+				<div class="hr"></div>
+				<div class="control_block">
+
+					<span class="text">Was this review helpful?</span>
+
+					<a href="javascript:void(0)" onclick="UserReviewVoteUp( '11439950' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteUpBtnall11439950"><span><i class="ico16 thumb_up"></i> Yes</span></a>
+					<a href="javascript:void(0)" onclick="UserReviewVoteDown( '11439950' )" class="btn_grey_black btn_small_thin ico_hover " id="RecommendationVoteDownBtnall11439950"><span><i class="ico16 thumb_down"></i> No</span></a>
+
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+		</div>
+	</div>
+
+				<div id="LoadMoreReviewsall">
+				<a href="javascript:void(0);" onclick="LoadMoreReviews( 247080, 5, 9223372036854775807, 'all', 'english' );" class="btn_darkblue_white_innerfade btn_medium">
+					<span>Load More Reviews</span>
+				</a>
+			</div>
+						<div id="ViewAllReviewsall" class="view_all_reviews_btn">
+				<a href="http://steamcommunity.com/app/247080/reviews/?browsefilter=toprated&snr=1_5_9_">Browse all 106 reviews</a>
+			</div>
+						<div id="LoadingMoreReviewsall" style="display: none" class="loading_more_reviews">
+				<img src="http://store.akamai.steamstatic.com/public/shared/images/throbber.gif" class="loading_more_reviews_throbber">
+				Loading reviews...			</div>
+		</div>
+			</div>
+		
+	</div>
+
+<!-- Right Column -->
+	<div class="rightcol">
+
+		
+		<div class="block" id="demo_block">
+		<div class="block_content block_content_inner underlined_links">
+										<div class="demo_area_button">
+																	<div class="demo_area_button">
+							<p><a href="http://store.steampowered.com/login/?redir=app%2F247080">Sign in</a> to add this game to your wishlist</p>
+						</div>
+									</div>
+						<div class="demo_area_button">
+				<a class="btn_grey_black btn_medium " href="#" onclick="ShowShareDialog(); return false;"><span>Share</span></a>
+				<span style="display: inline-block; width: 5px;"></span>
+				<a class="btn_grey_black btn_medium " href="#" onclick="ShowEmbedWidget(247080); return false;"><span>Embed</span></a>
+				<span style="display: inline-block; width: 5px;"></span>
+				<a id="ReportAppBtn" class="btn_grey_black btn_medium" href="javascript:void(0)" onclick="ShowReportDialog(247080)"><span data-store-tooltip="Report this Product"><i class="ico16 report"></i>&nbsp;</span></a>
+			</div>
+		</div>
+	</div>
+
+
+					<div class="block communitylink">
+				<div class="block_header">
+					<h4>Community</h4>
+				</div>
+				<div class="block_content">
+					<div class="block_content_inner">
+													<a class="linkbar" href="http://steamcommunity.com/app/247080/discussions/">
+								<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_forums.gif" width="16" height="16" border="0" align="top" /></div>
+								Visit the forums							</a>
+																			<a class="linkbar" href="http://steamcommunity.com/ogg/247080" target="_blank">
+								<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/v5/ico_community.gif" width="16" height="16" border="0" align="top" /></div>
+								Visit Official Game Group							</a>
+												<a class="linkbar" href="http://steamcommunity.com/actions/Search?T=ClanAccount&K=Crypt%20of%20the%20NecroDancer">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/v5/ico_find.png" width="16" height="16" border="0" align="top" /></div>
+							Find Community Groups						</a>
+					</div>
+
+					
+
+
+									</div>
+			</div>
+		
+		<div class="block game_details underlined_links">
+						<div class="block_header">
+				<h4></h4>
+			</div>
+			<div class="block_content">
+			<div class="block_content_inner" itemprop="review" itemscope itemtype="http://www.schema.org/Review">
+				
+
+				<div class="details_block">
+				<b>Title:</b> Crypt of the NecroDancer<br>
+
+								<b>Genre:</b> <a href="http://store.steampowered.com/genre/Action/?snr=1_5_9__408">Action</a>, <a href="http://store.steampowered.com/genre/Indie/?snr=1_5_9__408">Indie</a>, <a href="http://store.steampowered.com/genre/RPG/?snr=1_5_9__408">RPG</a>, <a href="http://store.steampowered.com/genre/Early%20Access/?snr=1_5_9__408">Early Access</a><br>
+				
+									<b>Developer:</b>
+																	<a href="http://store.steampowered.com/search/?developer=Brace%20Yourself%20Games&snr=1_5_9__408">Brace Yourself Games</a>
+									 	<br>
+				
+									<b>Publisher:</b>
+					<a href="http://store.steampowered.com/search/?publisher=Brace%20Yourself%20Games&snr=1_5_9__408">Brace Yourself Games</a>, <a href="http://store.steampowered.com/search/?publisher=Klei%20Entertainment&snr=1_5_9__408">Klei Entertainment</a>					<br>
+				
+								<b>Release Date:</b> 30 Jul 2014<br>
+								<b>Languages:</b>
+
+								<table  class="game_language_options" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <th style="width: 94px;"></th>
+                        <th style="width: 62px;"><b>Interface</b></th>
+                        <th style="width: 62px;"><b>Full audio</b></th>
+                        <th style="width: 62px;"><b>Subtitles</b></th>
+                    </tr><tr><th style="width: 94px; text-align: left;">English</th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/> </th><th style="width: 62px;"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_greencheck.png"/></th><th style="width: 62px;"></th></tr></table>
+								</div>
+
+
+
+				
+				<div class="details_block">
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=2"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_singlePlayer.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=2">Single-player</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=24"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_coop.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=24">Local Co-op</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=25"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_leaderboards.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=25">Steam Leaderboards</a></div>
+						</div>
+											<div class="game_area_details_specs">
+							<div class="icon"><a href="http://store.steampowered.com/search/?category2=28"><img src="http://store.akamai.steamstatic.com/public/images/ico/ico_controller.png" width="26" height="16" align="top" /></a></div>
+							<div class="name"><a href="http://store.steampowered.com/search/?category2=28">Full controller support</a></div>
+						</div>
+									</div>
+
+
+
+				<div class="details_block">
+											<a class="linkbar" href="http://necrodancer.com" target="_blank">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_web.gif" width="16" height="16" border="0" align="top"  ></div>
+							Visit the website <img src="http://store.akamai.steamstatic.com/public/images/v5/ico_external_link.gif" border="0" align="bottom">
+						</a>
+					
+					
+					
+					
+					
+											<a class="linkbar" href="http://store.steampowered.com/news/?appids=247080">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_history.gif" width="16" height="16" border="0" align="top" /></div>
+							View update history						</a>
+						<a class="linkbar" href="http://store.steampowered.com/news/?appids=247080">
+							<div class="rightblock"><img src="http://store.akamai.steamstatic.com/public/images/ico/link_news.gif" width="16" height="16" border="0" align="top" /></div>
+							Read related news						</a>
+									</div>
+			</div>
+			</div>
+					</div>
+
+		
+					<div class="block">
+				<div class="block_header"><h4>Awards</h4></div>
+				<div class="block_content block_content_inner">
+					<div id="AwardsDefault">
+					<ul class="bb_ul"><li>    <strong><i>Multiple Nominations</i></strong>, Independent Games Festival, Game Developers Conference, 2014<br></li><li>    <strong><i>Official Selection</i></strong>, IndieCade East, 2014<br></li><li>    <strong><i>Winner, Best Audio</i></strong>, Brazil Independent Game Festival, 2014<br></li><li>    <strong><i>Selected for the Indie MEGABOOTH</i></strong>, PAX East, 2014<br></li><li>    <strong><i>Official Selection</i></strong>, IndieCade West, 2013<br></li><li>    <strong><i>Selected for the Indie Game Fest</i></strong>, Tokyo Game Show, 2013<br></li><li>    <strong><i>Fantastic Arcade Showcase Selection</i></strong>, Fantastic Fest, 2013<br></li><li>    <strong><i>Destructoid Editor's Choice</i></strong>, PAX Prime, 2013<br></li><li>    <strong><i>Selected for the Indie MEGABOOTH</i></strong>, PAX Prime, 2013<br></li><li>    <strong><i>Official Selection</i></strong>, Toronto Gamercamp Festival, 2013<br></li><li>    <strong><i>Official Selection</i></strong>, Portland Stumpquest Game Fest, 2013</li></ul>
+										</div>
+
+									</div>
+
+			</div>
+		
+		<br>
+
+
+	</div>
+	<!-- End Right Column -->
+	<div style="clear: both;"></div>
+
+			<div class="hover game_hover" id="global_hover" style="display: none; left: 0; top: 0;">
+			<div class="game_hover_box hover_box">
+				<div class="content" id="global_hover_content">
+				</div>
+			</div>
+			<div class="hover_arrow_left"></div>
+			<div class="hover_arrow_right"></div>
+		</div>
+</div>
+</div>
+
+<div id="gotSteamModal" style="display:none;">
+	<div id="top_band">
+		<div id="modal_close"><a href="javascript:hideModal('gotSteamModal')"><img src="http://store.akamai.steamstatic.com/public/images/x9x9.gif" width="9" height="9" border="0" /></a></div>
+	</div>
+	<div id="got_steam_box">
+		<h1>Got Steam?</h1>
+		<p>You need to have Steam installed to get <strong id="gotSteam_AppName"></strong></p>
+		<div id="gotsteam_buttons">
+			<a id="gotSteam_SteamURL" href="" class="btn_white leftbtn">
+				<h3>Yes, I have Steam</h3>
+				<h5>OPEN STEAM</h5>
+			</a>
+			<a href="http://store.steampowered.com/about/" class="btn_white">
+				<h3>No, I do not have Steam</h3>
+				<h5>FREE 1.5 MB DOWNLOAD</h5>
+			</a>
+			<div style="clear: left;"></div>
+		</div>
+		<div id="low_block">
+			<div id="steam_ico"><img src="http://store.akamai.steamstatic.com/public/images/steam_ico.gif" width="40" height="40" border="0" /></div>
+			Steam is the premiere desktop gaming platform. It's free to join and easy to use. <a href="http://store.steampowered.com/about/">Learn more about Steam.</a>
+		</div></div>
+</div>
+<div id="modalBG" style="display: none;"></div>
+<!-- Footer -->
+<div id="footer_spacer" class=""></div>
+<div id="footer">
+	<div class="footer_content">
+		<div class="rule"></div>
+		
+		<div id="footer_nav">
+		
+					
+							<span class="pulldown" id="footer_genre_pulldown">
+					SHOP BY GENRE				</span>
+				<div class="popup_block_new" id="footer_genre_dropdown" style="display: none;">
+					<div class="popup_body popup_menu">
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Free%20to%20Play?snr=1_44_44__20">
+								Free to Play							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Action?snr=1_44_44__20">
+								Action							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Adventure?snr=1_44_44__20">
+								Adventure							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Strategy?snr=1_44_44__20">
+								Strategy							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/RPG?snr=1_44_44__20">
+								RPG							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Indie?snr=1_44_44__20">
+								Indie							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Massively%20Multiplayer?snr=1_44_44__20">
+								Massively Multiplayer							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Casual?snr=1_44_44__20">
+								Casual							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Simulation?snr=1_44_44__20">
+								Simulation							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Racing?snr=1_44_44__20">
+								Racing							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Sports?snr=1_44_44__20">
+								Sports							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Accounting?snr=1_44_44__20">
+								Accounting							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Animation%20%26%20Modeling?snr=1_44_44__20">
+								Animation & Modeling							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Audio%20Production?snr=1_44_44__20">
+								Audio Production							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Design%20%26%20Illustration?snr=1_44_44__20">
+								Design & Illustration							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Education?snr=1_44_44__20">
+								Education							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Photo%20Editing?snr=1_44_44__20">
+								Photo Editing							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Software%20Training?snr=1_44_44__20">
+								Software Training							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Utilities?snr=1_44_44__20">
+								Utilities							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Video%20Production?snr=1_44_44__20">
+								Video Production							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Web%20Publishing?snr=1_44_44__20">
+								Web Publishing							</a>
+													<a class="popup_menu_item" href="http://store.steampowered.com/genre/Early%20Access?snr=1_44_44__20">
+								Early Access							</a>
+											</div>
+				</div>
+										<span class="pulldown" id="footer_category_pulldown">
+				SHOP BY CATEGORY			</span>
+			<div class="popup_block_new" id="footer_category_dropdown" style="display: none;">
+								<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://store.steampowered.com/freestuff/demos/?snr=1_44_44__21">
+						Demos					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/freestuff/videos/?snr=1_44_44__21">
+						Videos					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/search/?category2=21&snr=1_44_44__21">
+						Downloadable Content					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/browse/publishers?snr=1_44_44__21">
+						Game Publisher Catalogs					</a>
+																<a class="popup_menu_item" href="http://store.steampowered.com/browse/ut1?snr=1_44_44__21">
+							Games Under &#36;10 USD						</a>
+											<a class="popup_menu_item" href="http://store.steampowered.com/browse/ut2?snr=1_44_44__21">
+							Games Under &#36;5 USD						</a>
+									</div>
+							</div>
+			<span class="pulldown" id="footer_steam_pulldown">
+				ABOUT STEAM			</span>
+			<div class="popup_block_new" id="footer_steam_dropdown" style="display: none;">
+								<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://store.steampowered.com/about/?snr=1_44_44__22">
+						What is Steam?					</a>
+					<!--
+					<a class="popup_menu_item" href="">
+						Download Steam now					</a>
+					-->
+					<a class="popup_menu_item" target="_blank" href="https://support.steampowered.com/kb_article.php?p_faqid=549#gifts">
+						Gifting on Steam					</a>
+					<a class="popup_menu_item" href="https://steamcommunity.com/?snr=1_44_44__22">
+						The Steam Community					</a>
+				</div>
+							</div>
+	
+			<span class="pulldown" id="footer_valve_pulldown">
+				ABOUT VALVE			</span>
+			<div class="popup_block_new" id="footer_valve_dropdown" style="display: none;">
+				<div class="popup_body popup_menu">
+					<a class="popup_menu_item" target="_blank" href="http://www.valvesoftware.com/about.html">
+						About Valve					</a>
+					<a class="popup_menu_item" target="_blank" href="http://www.valvesoftware.com/business/">
+						Business Solutions					</a>
+					<a class="popup_menu_item" target="_blank" href="http://www.steampowered.com/steamworks/">
+						Steamworks					</a>
+					<a class="popup_menu_item" target="_blank" href="http://source.valvesoftware.com/">
+						Source Engine					</a>
+					<a class="popup_menu_item" target="_blank" href="https://cafe.steampowered.com">
+						Cyber Caf&eacute;s					</a>
+					<a class="popup_menu_item" target="_blank" href="http://www.valvesoftware.com/jobs.html">
+						Jobs					</a>
+				</div>
+			</div>
+			
+			
+			<span class="pulldown" id="footer_help_pulldown">
+				HELP			</span>
+			<div class="popup_block_new" id="footer_help_dropdown" style="display: none;">
+								<div class="popup_body popup_menu">
+					<a class="popup_menu_item" target="_blank" href="http://support.steampowered.com/">
+						Support					</a>
+					<a class="popup_menu_item" target="_blank" href="http://store.steampowered.com/forums/?snr=1_44_44__23">
+						Forums					</a>
+					<a class="popup_menu_item" target="_blank" href="http://store.steampowered.com/stats/?snr=1_44_44__23">
+						Stats					</a>
+				</div>
+							</div>
+			
+			
+			<span class="pulldown" id="footer_tools_pulldown">
+				TOOLS			</span>
+			<div class="popup_block_new" id="footer_tools_dropdown" style="display: none;">
+				<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://storefront.steampowered.com/download/hldsupdatetool.exe">
+						Windows HLDS Update Tool					</a>
+					<a class="popup_menu_item" href="http://storefront.steampowered.com/download/hldsupdatetool.bin">
+						Linux HLDS Update Tool					</a>
+				</div>
+			</div>
+			
+			
+			<span class="pulldown" id="footer_feeds_pulldown">
+				NEWS FEEDS			</span>
+			<div class="popup_block_new" id="footer_feeds_dropdown" style="display: none;">
+				<div class="popup_body popup_menu">
+					<a class="popup_menu_item" href="http://store.steampowered.com/feeds/news.xml">
+						<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_rss2.gif" width="13" height="13" border="0" alt="" align="top">&nbsp;&nbsp;Steam News					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/feeds/newreleases.xml">
+						<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_rss2.gif" width="13" height="13" border="0" alt="" align="top">&nbsp;&nbsp;Game Releases					</a>
+					<a class="popup_menu_item" href="http://store.steampowered.com/feeds/daily_deals.xml">
+						<img src="http://store.akamai.steamstatic.com/public/images/ico/ico_rss2.gif" width="13" height="13" border="0" alt="" align="top">&nbsp;&nbsp;Daily Deals					</a>
+				</div>
+			</div>
+			<div style="clear: left;"></div>
+			
+			<script type="text/javascript">
+				RegisterFlyout( 'footer_genre_pulldown', 'footer_genre_dropdown', null, null, true );
+				RegisterFlyout( 'footer_category_pulldown', 'footer_category_dropdown', null, null, true );
+				RegisterFlyout( 'footer_steam_pulldown', 'footer_steam_dropdown', null, null, true );
+				RegisterFlyout( 'footer_valve_pulldown', 'footer_valve_dropdown', null, null, true );
+				RegisterFlyout( 'footer_help_pulldown', 'footer_help_dropdown', null, null, true );
+				RegisterFlyout( 'footer_tools_pulldown', 'footer_tools_dropdown', null, null, true );
+				RegisterFlyout( 'footer_feeds_pulldown', 'footer_feeds_dropdown', null, null, true );
+			</script>
+		</div>
+
+		<div class="rule"></div>
+
+		<div class="btn_client_small get_game_on_steam">
+			<a target="_blank" href="http://steamcommunity.com/greenlight">Get your game on Steam</a>
+		</div>
+
+		<div>
+			<a target="_blank" href="http://www.valvesoftware.com/about.html">About Valve</a> 
+			| <a target="_blank" href="http://www.valvesoftware.com/business/">Business Solutions</a> 
+			| <a target="_blank" href="http://www.steampowered.com/steamworks/">Steamworks</a>
+			| <a target="_blank" href="http://source.valvesoftware.com/">Source Engine</a>
+			| <a target="_blank" href="https://cafe.steampowered.com">Cyber Caf&eacute;s</a> 
+			| <a target="_blank" href="http://www.valvesoftware.com/jobs.html">Jobs</a>
+		</div>
+
+
+		<div class="rule"></div>
+		<div id="footer_logo"><a target="_blank" href="http://www.valvesoftware.com"><img src="http://store.akamai.steamstatic.com/public/images/logo_valve_footer.jpg" alt="Valve Software" border="0" /></a></div>
+		<div id="footer_text">
+			<div>&copy; 2014 Valve Corporation.  All rights reserved.  All trademarks are property of their respective owners in the US and other countries.</div>
+			<div>VAT included in all prices where applicable.</div>
+			<div class="valve_links">
+			<a target="_blank" href="http://store.steampowered.com/privacy_agreement/">Privacy Policy</a>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+			<a target="_blank" href="http://www.valvesoftware.com/legal.htm">Legal</a>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+			<a target="_blank" href="http://store.steampowered.com/subscriber_agreement/">Steam Subscriber Agreement</a>
+							</div>
+		</div>
+	</div>
+</div><!-- End Footer -->
+
+<div id="EmbedModal"  style="display: none">
+	<div id="widget_create">
+		<p>You can use this widget-maker to generate a bit of HTML that can be embedded in your website to easily allow customers to purchase this game on Steam.</p>
+
+					<p class="small">There is more than one way to buy this game. Please select a specific package to create a widget for:</p>
+			<div class="w_options">
+									<div class="w_option">
+						<input type="radio" name="w_rsubid" id="wp_47831" value="47831">
+						<label for="wp_47831">Crypt of the NecroDancer</label>
+					</div>
+									<div class="w_option">
+						<input type="radio" name="w_rsubid" id="wp_47832" value="47832">
+						<label for="wp_47832">Crypt of the NecroDancer + Soundtrack</label>
+					</div>
+							</div>
+				<p class="small">Enter up to 375 characters to add a description to your widget:</p>
+		<textarea name="w_text" placeholder="Crypt of the NecroDancer is a hardcore roguelike rhythm game. Can you survive this deadly dungeon of dance? Groove to the epic Danny Baranowsky soundtrack, or select songs from your own MP3 collection!" maxlength="375"></textarea>
+
+		<div class="buttoncontainer">
+			<a class="btn_green_white_innerfade btn_medium " href="#" onclick="CreateWidget(247080); return false;"><span>Create widget</span></a>
+		</div>
+	</div>
+	<div id="widget_finished" style="display: none;">
+		<div id="widget_container"></div>
+
+		<p class="small">Copy and paste the HTML below into your website to make the above widget appear</p>
+		<textarea id="widget_code" style=""></textarea>
+	</div>
+
+</div>
+
+<div id="ShareModal" style="display: none">
+	<div class="share">Share:&nbsp; <a target="_blank" href="http://store.steampowered.com/share/facebook/app/247080" title="Share on Facebook"><img src="http://store.akamai.steamstatic.com/public/images/v5/social/facebook.gif"></a>&nbsp; <a target="_blank" href="http://store.steampowered.com/share/twitter/app/247080" title="Share on Twitter"><img src="http://store.akamai.steamstatic.com/public/images/v5/social/twitter.gif"></a>&nbsp; <a target="_blank" href="http://store.steampowered.com/share/reddit/app/247080" title="Share on Reddit"><img src="http://store.akamai.steamstatic.com/public/images/v5/social/reddit.gif"></a></div></div>
+
+	<div id="app_tagging_modal" class="app_tag_modal nologin" style="display: none;">
+		<div class="app_tag_modal_content">
+			<div class="app_tag_modal_seperator"></div>
+			<div class="app_tag_modal_left">
+				<h2>Popular user-defined tags for this product:<span class="app_tag_modal_tooltip" data-store-tooltip="These are tags applied to the product by the most users.  You can click a tag to find other products with that tag applied.  Or, you can hit the plus symbol for any existing tags to increase that tag's popularity on this product.">(?)</span></h2>
+				<div class="app_tags popular_tags">
+				</div>
+			</div>
+			<div class="app_tag_modal_right">
+									<h2>Sign in</h2>
+					<p>Sign in to add your own tags to this product.</p>
+					<p>
+						<a class="btn_green_white_innerfade btn_medium" href="https://store.steampowered.com/login/?redir=app/247080">
+							<span>Sign in</span>
+						</a>
+					</p>
+							</div>
+			<div style="clear: both;"></div>
+		</div>
+		<div class="app_tag_modal_beta_callout">
+			<img src="http://store.akamai.steamstatic.com/public/images/v6/tag_betatag.png">
+			Steam tagging is in beta.  Click <a href="http://store.steampowered.com/tag/">here</a> to learn more.		</div>
+	</div>
+		<script type="text/javascript">
+		$J( function() {
+			InitAppTagModal( 247080,
+				[{"tagid":1716,"name":"Rogue-like","count":38,"browseable":true},{"tagid":1752,"name":"Rhythm","count":38,"browseable":true},{"tagid":1756,"name":"Great Soundtrack","count":32,"browseable":true},{"tagid":7208,"name":"Female Protagonist","count":28,"browseable":true},{"tagid":492,"name":"Indie","count":25,"browseable":true},{"tagid":3964,"name":"Pixel Graphics","count":22,"browseable":true},{"tagid":122,"name":"RPG","count":18,"browseable":true},{"tagid":1764,"name":"Hardcore","count":13,"browseable":true},{"tagid":493,"name":"Early Access","count":9,"browseable":true},{"tagid":1720,"name":"Dungeon Crawler","count":9,"browseable":true}],
+				[],
+				"1_5_9__410",
+				"1_5_9__411",
+				null			);
+		})
+	</script>
+
+</body>
+</html>

--- a/test/doubles/logger_double.rb
+++ b/test/doubles/logger_double.rb
@@ -1,0 +1,33 @@
+class LoggerDouble
+  LOG_LEVELS = %i(debug info warn error fatal unknown)
+
+  def initialize
+    @logs = {}
+  end
+
+  def logs_for(level)
+    loggable?(level) ? @logs[level] : raise(StandardError, "Invalid log level: #{level}")
+  end
+
+  def method_missing(method, *args)
+    if loggable?(method)
+      define_and_log(method, *args)
+    else
+      super
+    end
+  end
+
+  def define_and_log(method, *args)
+    class_eval <<-RUBY
+    def #{method}(message)
+      @logs[:#{method}] ||= []
+      @logs[:#{method}] << message
+    end
+    RUBY
+    public_send(method, *args)
+  end
+
+  def loggable?(level)
+    LOG_LEVELS.include?(level)
+  end
+end

--- a/test/fixtures/steam_games.yml
+++ b/test/fixtures/steam_games.yml
@@ -1,0 +1,25 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+
+cs_source:
+  title: "Counter Strike Source"
+  app_id: 1234
+  header_image: 'http://foo.com/abra.jpg'
+  capsule_image: 'http://foo.com/cadabra.jpg'
+  categories:
+    - 1
+  multi_player: true
+  updated_at: 2010-01-01
+
+cs_go:
+  title: "Counter Strike Source"
+  app_id: 7890
+  header_image: 'http://foo.com/abra.jpg'
+  capsule_image: 'http://foo.com/cadabra.jpg'
+  categories:
+    - 1
+  multi_player: true

--- a/test/models/catalog_page_details_test.rb
+++ b/test/models/catalog_page_details_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class CatalogPageDetailsTest < ActiveSupport::TestCase
+  attr_reader :page_details
+
+  setup do
+    @page_details = CatalogPageDetails.new(fetch_page(name: 'counter_strike.html'))
+  end
+
+  test "getting the title for a game" do
+    assert_equal 'Counter-Strike: Global Offensive', page_details.title
+  end
+
+  test "getting the game_id for a game" do
+    assert_equal 730, page_details.game_id
+  end
+
+  test "getting the header_image strips out the uri parameters" do
+    assert_equal 'http://cdn.akamai.steamstatic.com/steam/apps/730/header_292x136.jpg', page_details.header_image
+  end
+
+  test "getting the capsule_image strips out the uri parameters" do
+    assert_equal 'http://cdn.akamai.steamstatic.com/steam/apps/730/capsule_231x87.jpg', page_details.capsule_image
+  end
+
+  test "getting the page details for a multiplayer game" do
+    assert page_details.multi_player?, "Counter Strike is a multi-player game"
+  end
+
+  test "getting the page details for a single player game" do
+    page_details = CatalogPageDetails.new(fetch_page(name: 'necrodancer.html'))
+    assert page_details.single_player?, "Crypt of the Necrodancer is a single player game"
+  end
+end

--- a/test/models/catalog_page_details_test.rb
+++ b/test/models/catalog_page_details_test.rb
@@ -31,4 +31,9 @@ class CatalogPageDetailsTest < ActiveSupport::TestCase
     page_details = CatalogPageDetails.new(fetch_page(name: 'necrodancer.html'))
     assert page_details.single_player?, "Crypt of the Necrodancer is a single player game"
   end
+
+  test "initalizing a details value object" do
+    details = CatalogPageDetails::Details.new(page_details.as_hash)
+    assert_equal 'Counter-Strike: Global Offensive', details.title
+  end
 end

--- a/test/models/catalog_page_details_test.rb
+++ b/test/models/catalog_page_details_test.rb
@@ -27,13 +27,14 @@ class CatalogPageDetailsTest < ActiveSupport::TestCase
     assert page_details.multi_player?, "Counter Strike is a multi-player game"
   end
 
-  test "getting the page details for a single player game" do
-    page_details = CatalogPageDetails.new(fetch_page(name: 'necrodancer.html'))
-    assert page_details.single_player?, "Crypt of the Necrodancer is a single player game"
-  end
-
-  test "initalizing a details value object" do
-    details = CatalogPageDetails::Details.new(page_details.as_hash)
-    assert_equal 'Counter-Strike: Global Offensive', details.title
+  test "as_hash for game details" do
+    expected_hash = {
+      multi_player: true,
+      app_id: 730,
+      capsule_image: 'http://cdn.akamai.steamstatic.com/steam/apps/730/capsule_231x87.jpg',
+      header_image: 'http://cdn.akamai.steamstatic.com/steam/apps/730/header_292x136.jpg',
+      title: 'Counter-Strike: Global Offensive'
+    }
+    assert_equal expected_hash, page_details.as_hash
   end
 end

--- a/test/models/game_import_pipeline_test.rb
+++ b/test/models/game_import_pipeline_test.rb
@@ -29,8 +29,25 @@ class GameImportPipelineTest < ActiveSupport::TestCase
     end
 
     assert_equal 2, results.length
-    assert_equal cs, results[0]
-    assert_equal necro, results[1]
+    assert results.delete(cs)
+    assert results.delete(necro)
+  end
+
+  test "extract_details takes all the page data and makes it usable" do
+    pages = channel!(String, 2)
+    pages << cs
+    pages << necro
+
+    details_chan = pipeline.extract_details(pages, 2, error)
+
+    results = []
+    async_process do |s|
+      s.case(details_chan, :receive) { |d| results << d }
+    end
+
+    assert_equal 2, results.count
+    assert results.select{ |r| r.title == 'Counter Strike: Global Offensive' }
+    assert results.select{ |r| r.title == 'Crypt of the NecroDancer' }
   end
 
   def async_process(&blk)

--- a/test/models/game_import_pipeline_test.rb
+++ b/test/models/game_import_pipeline_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class GameImportPipelineTest < ActiveSupport::TestCase
+  attr_reader :pipeline
+  setup do
+    @pipeline = GameImportPipeline.new
+    pipeline.timeout = 0.1
+  end
+
+  test "retrieving missing or outdated games includes games in the DB and those that do not exist" do
+    games = [4567, steam_games(:cs_source).app_id, steam_games(:cs_go).app_id]
+    missing_games = pipeline.retrive_missing_or_outdated_games(games)
+    assert_equal [4567, steam_games(:cs_source).app_id].sort, missing_games.sort
+  end
+
+  test "fetch_pages fetches all the pages from steam" do
+    cs = fetch_page(name: 'counter_strike.html')
+    necro = fetch_page(name: 'necrodancer.html')
+  end
+end

--- a/test/models/game_import_pipeline_test.rb
+++ b/test/models/game_import_pipeline_test.rb
@@ -8,6 +8,7 @@ class GameImportPipelineTest < ActiveSupport::TestCase
     @necro = fetch_page(name: 'necrodancer.html')
     @pipeline = GameImportPipeline.new
     pipeline.timeout = 0.1
+    pipeline.error = @error
   end
 
   test "retrieving missing or outdated games includes games in the DB and those that do not exist" do

--- a/test/models/logger_double_test.rb
+++ b/test/models/logger_double_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class LoggerDoubleTest < ActiveSupport::TestCase
+  attr_reader :logger
+
+  TESTS = {
+    assert_methods_missing: LoggerDouble::LOG_LEVELS,
+    debug: "Hello World",
+    info: "Goodbye Lenin",
+    warn: "Here's Johnny",
+    error: "Gotta catch em All",
+    fatal: "Hostage Down",
+    unknown: "dunno",
+    assert_methods_exist: LoggerDouble::LOG_LEVELS
+  }
+
+  setup do
+    @logger = LoggerDouble.new
+  end
+
+  test "that logging works the way it should" do
+    TESTS.each do |test, value|
+      case test
+      when :assert_methods_missing, :assert_methods_exist
+        public_send(test, value)
+      else
+        logger.public_send(test, value)
+        assert_equal [value], logger.logs_for(test)
+      end
+    end
+  end
+
+  def assert_methods_exist(methods)
+    methods.each do |method|
+      assert logger.respond_to?(method), "The LoggerDouble should be responding to #{method}"
+    end
+  end
+
+  def assert_methods_missing(methods)
+    methods.each do |method|
+      refute logger.respond_to?(method), "The LoggerDouble should not be responding to #{method}"
+    end
+  end
+
+end

--- a/test/models/steam_catalog_page_test.rb
+++ b/test/models/steam_catalog_page_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class SteamCatalogPageTest < ActiveSupport::TestCase
+  test "retrieving the body of a page" do
+    stub_request(:get, 'http://foobar.com/1234').to_return(body: 'hello world', status: 200)
+    page = SteamCatalogPage.new(1234, endpoint: 'http://foobar.com')
+    assert_equal 'hello world', page.body
+    assert_requested :get, 'http://foobar.com/1234'
+  end
+
+  test "getting the body of a page multiple times only makes a single HTTP request" do
+    stub_request(:get, 'http://foobar.com/1234').to_return(body: 'hello world', status: 200)
+    page = SteamCatalogPage.new(1234, endpoint: 'http://foobar.com')
+    5.times { page.body }
+    assert_requested :get, 'http://foobar.com/1234', times: 1
+  end
+
+  test "errors raised in responses are passed raised to the caller" do
+    stub_request(:any, 'http://foobar.com/1234').to_return(body: 'not found', status: 404)
+    begin
+      page = SteamCatalogPage.new(1234, endpoint: 'http://foobar.com')
+      page.body
+      flunk("An HTTP Error should have been raised")
+    rescue RestClient::Exception => e
+      pass
+    end
+  end
+end

--- a/test/models/steam_game_test.rb
+++ b/test/models/steam_game_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SteamGameTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/remote/game_import_pipeline_test.rb
+++ b/test/remote/game_import_pipeline_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+module Remote
+  class GameImportPipelineTest < Remote::Test
+
+    test "importing a list of games through the pipeline" do
+      apps = Remote::Test::APPS
+      app_ids = apps.keys
+      pipeline = GameImportPipeline.new
+      pipeline.logger = Rails.logger
+
+      assert_difference "SteamGame.count", app_ids.length do
+        assert pipeline.import(app_ids), "The pipeline threw an error or failed to import all the apps"
+      end
+
+      apps.each do |app_id, title|
+        game = SteamGame.find_by(app_id: app_id)
+        assert_equal(title, game.title)
+      end
+    end
+  end
+end

--- a/test/remote/steam_catalog_page_test.rb
+++ b/test/remote/steam_catalog_page_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+module Remote
+  class SteamCatalogPageTest < Remote::Test
+    test "making a real HTTP call to the Steam Storefront" do
+      Remote::Test::APPS.each do |app_id, title|
+        page = SteamCatalogPage.new(app_id)
+        assert_match title, page.body
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,4 +16,13 @@ class ActiveSupport::TestCase
   def fetch_page(name: 'counter_strike.html')
     File.read(Rails.root + "test/data/game_pages/#{name}")
   end
+
+  def assert_raises_child_of(error, &blk)
+    begin
+      blk.yield
+    rescue => e
+      parent = e.class.superclass
+      assert_equal error, parent, "Expected an error of type #{error} but received of type #{parent} instead"
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path(File.dirname(__FILE__) + '/doubles/logger_double')
 require 'rails/test_help'
 require "minitest/autorun"
 require 'webmock/minitest'
+require 'pry'
+require 'pry-debugger'
 
 class ActiveSupport::TestCase
   ActiveRecord::Migration.check_pending!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,3 +29,22 @@ class ActiveSupport::TestCase
     end
   end
 end
+
+module Remote
+  class Test < ActiveSupport::TestCase
+    APPS = {
+      227600 => 'Castle of Illusion',
+      237930 => 'Transistor',
+      620 => 'Portal 2',
+      730 => 'Counter-Strike: Global Offensive'
+    }
+
+    setup do
+      WebMock.allow_net_connect!
+    end
+
+    teardown do
+      WebMock.disable_net_connect!
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require "minitest/autorun"
+require 'webmock/minitest'
 
 class ActiveSupport::TestCase
   ActiveRecord::Migration.check_pending!
@@ -11,5 +13,7 @@ class ActiveSupport::TestCase
   # -- they do not yet inherit this setting
   fixtures :all
 
-  # Add more helper methods to be used by all tests here...
+  def fetch_page(name: 'counter_strike.html')
+    File.read(Rails.root + "test/data/game_pages/#{name}")
+  end
 end


### PR DESCRIPTION
This is just for parts of the scraping pipeline.

One part simply pulls the data down

Another part transforms the raw data into something that I think is useful.

Details:
1. From what I can see, **capsule_image** is the logo that doesn't change. **header_image** changes I'm pretty sure depending on whatever Steams marketing and design team decides I guess.
2. Instead of having to remember what app id we were working with we can just scrape it out of the page
3. We collect all the categories for a game, this means we can add more features later if we want. It also means that if a game supports single player and multi-player we'll know (though for our purpose this really doesn't matter).

Please review @carsonb @davefp
