### PR TITLE
Removes unused code, touches up user search + API

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -5,7 +5,6 @@ class WelcomeController < ApplicationController
 
   def index
     @friends = retrieve_friends
-    @games = retrieve_games
   end
 
   def search
@@ -15,10 +14,6 @@ class WelcomeController < ApplicationController
   def retrieve_friends
     current_user.update_friends unless current_user.friends?
     User.fetch_and_or_store(current_user.friends)
-  end
-
-  def retrieve_games
-    steam_service.retrieve_games(current_user.uid)
   end
 
   private

--- a/app/models/steam_service.rb
+++ b/app/models/steam_service.rb
@@ -4,15 +4,6 @@ class SteamService
     @current_user_id = user_id
   end
 
-  def retrieve_friends
-    begin
-      friends = Steam::User.friends(@current_user_id)
-    rescue Steam::JSONError
-      return []
-    end
-    Steam::User.summaries(friends.map{|f| f['steamid']}).sort { |a,b| a['personaname'].downcase <=> b['personaname'].downcase }
-  end
-
   def retrieve_games(user_id)
     begin
       games = Steam::Player.owned_games(user_id, params: {include_appinfo: 1})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
     steam_accounts = steam_users(missing_accounts)
     steam_accounts.each(&:save)
 
-    where(uid: steam_ids)
+    where(uid: steam_ids).order('nickname ASC')
   end
 
   def self.missing_users(ids)
@@ -42,6 +42,10 @@ class User < ActiveRecord::Base
   end
 
   def steam_friends
-    Steam::User.friends(uid)
+    begin
+      Steam::User.friends(uid)
+    rescue Steam::JSONError
+      return []
+    end
   end
 end


### PR DESCRIPTION
Why do we catch `Steam::JSONError`? Because the Steam API (and thus the gem) is kinda crappy and gives us an error if there are no friends (e.g., the user's profile is private)
